### PR TITLE
[BUGFIX] Wrong class used for menu urls when checking ACLs

### DIFF
--- a/Classes/Controller/Backend/ApplicationController.php
+++ b/Classes/Controller/Backend/ApplicationController.php
@@ -82,7 +82,7 @@ class ApplicationController extends AbstractBackendController
         foreach ($this->menuUrls as $url) {
             //If extbase_acl is loaded, reduce menu urls to the ones actually allowed
             if (ExtensionManagementUtility::isLoaded("extbase_acl")) {
-                if (!\Pagemachine\ExtbaseAcl\Manager\ActionAccessManager::getInstance()->isActionAllowed(__CLASS__, $url['action'])) {
+                if (!\Pagemachine\ExtbaseAcl\Manager\ActionAccessManager::getInstance()->isActionAllowed(static::class, $url['action'])) {
                     continue;
                 }
             }


### PR DESCRIPTION
__CLASS__ refers to the class the code is implemented in, while static::class uses the actual class of the current object (which inherits the code).

The latter is correct here as f.ex. the ArchivedApplicationController can have different ACL settings than the ApplicationController.