### PR TITLE
[BUGFIX] Add empty default options for all BE application select fields

### DIFF
--- a/Classes/Domain/Model/ApplicationB.php
+++ b/Classes/Domain/Model/ApplicationB.php
@@ -257,7 +257,7 @@ class ApplicationB extends ApplicationA
      * @param SJBR\StaticInfoTables\Domain\Model\Country $country
      * @return void
      */
-    public function setCountry(Country $country)
+    public function setCountry(Country $country = null)
     {
         $this->country = $country;
     }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -716,6 +716,11 @@
 				<target> Löschen</target>
 			</trans-unit>
 
+			<trans-unit id="tx_ats.label.select.undefined">
+				<source>Undefined</source>
+				<target>Keine Angabe</target>
+			</trans-unit>
+
 			<trans-unit id="be.label.MyApplications">
 				<source>My Applications</source>
 				<target>Meine Bewerbungen</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -595,6 +595,10 @@
 			<source> Remove</source>
 		</trans-unit>
 
+	  <trans-unit id="tx_ats.label.select.undefined">
+		<source>Undefined</source>
+	  </trans-unit>
+
 	  <!-- Message labels -->
 
 		<trans-unit id="tx_ats.message.subject">

--- a/Resources/Private/Partials/Backend/Application/Field/SelectCountry.html
+++ b/Resources/Private/Partials/Backend/Application/Field/SelectCountry.html
@@ -6,7 +6,7 @@
 		</label>
 	</td>
 	<td>
-			<s:form.select name="staticInfoTablesCountry" property="{fieldName}" staticInfoTable="country" optionLabelField="shortNameEn" options="{}" class="form-control"/>
+			<s:form.select name="staticInfoTablesCountry" property="{fieldName}" staticInfoTable="country" optionLabelField="shortNameEn" options="{}" class="form-control" defaultOptionValue="" defaultOptionLabel="{f:translate(key:'tx_ats.label.select.undefined')}" />
 		</div>
 	</td>
 </tr>

--- a/Resources/Private/Partials/Backend/Application/Field/SelectNationality.html
+++ b/Resources/Private/Partials/Backend/Application/Field/SelectNationality.html
@@ -6,7 +6,7 @@
 		</label>
 	</td>
 	<td>
-			<s:form.select name="staticInfoTablesCountry" property="{fieldName}" staticInfoTable="country" optionLabelField="shortNameEn" optionValueField="isoCodeA3" options="{}" class="form-control"/>
+			<s:form.select name="staticInfoTablesCountry" property="{fieldName}" staticInfoTable="country" optionLabelField="shortNameEn" optionValueField="isoCodeA3" options="{}" class="form-control" defaultOptionValue="" defaultOptionLabel="{f:translate(key:'tx_ats.label.select.undefined')}" />
 		</div>
 	</td>
 </tr>

--- a/Resources/Private/Partials/Backend/Application/Field/SelectTranslated.html
+++ b/Resources/Private/Partials/Backend/Application/Field/SelectTranslated.html
@@ -11,6 +11,8 @@
 			    options="{options}"
 			    translationPrefix="{translationKey}."
 			    extensionName="ats"
+					prependOptionValue=""
+					prependOptionLabel="{f:translate(key:'tx_ats.label.select.undefined')}"
 			    class="form-control"
 			  />
 		</div>

--- a/Resources/Private/Partials/Backend/Application/Field/Selectbox.html
+++ b/Resources/Private/Partials/Backend/Application/Field/Selectbox.html
@@ -8,6 +8,8 @@
 			<f:form.select
 				property="{fieldName}"
 				options="{fieldOptions}"
+				prependOptionValue=""
+				prependOptionLabel="{f:translate(key:'tx_ats.label.select.undefined')}"
 				class="form-control" />
 		</div>
 	</td>


### PR DESCRIPTION
These empty fields should prevent that the first option in a selectfield is automatically set once the edit form is saved - even if the field was initially blank (because no FE input was given).