### PR TITLE
[BUGFIX] Statistics module uses different docheader menu code

### DIFF
--- a/Classes/Controller/Backend/ApplicationController.php
+++ b/Classes/Controller/Backend/ApplicationController.php
@@ -21,7 +21,6 @@ use PAGEmachine\Ats\Service\DuplicationService;
 use PAGEmachine\Ats\Service\ExtconfService;
 use PAGEmachine\Ats\Traits\StaticCalling;
 use PAGEmachine\Ats\Workflow\WorkflowManager;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
@@ -60,57 +59,6 @@ class ApplicationController extends AbstractBackendController
         "listAll" => ["action" => "listAll", "label" => "be.label.AllApplications"],
         "listMine" => ["action" => "listMine", "label" => "be.label.MyApplications"],
     ];
-
-    /**
-     * Builds the backend docheader menu with actions
-     *
-     * @return void
-     */
-    public function buildMenu()
-    {
-        if (!array_key_exists($this->request->getControllerActionName(), $this->menuUrls)) {
-            return;
-        }
-
-        $menuRegistry = $this->getMenuRegistry();
-
-        $uriBuilder = $this->controllerContext->getUriBuilder();
-
-        $menu = $menuRegistry->makeMenu()
-            ->setIdentifier("actions");
-
-        foreach ($this->menuUrls as $url) {
-            //If extbase_acl is loaded, reduce menu urls to the ones actually allowed
-            if (ExtensionManagementUtility::isLoaded("extbase_acl")) {
-                if (!\Pagemachine\ExtbaseAcl\Manager\ActionAccessManager::getInstance()->isActionAllowed(static::class, $url['action'])) {
-                    continue;
-                }
-            }
-
-            $isActive = $this->request->getControllerActionName() === $url['action'] ? true : false;
-            $uri = $uriBuilder
-                ->reset()
-                ->uriFor($url['action'], [], $this->request->getControllerName(), null, null);
-            $menuItem = $menu->makeMenuItem()
-                ->setHref($uri)
-                ->setTitle($this->callStatic(LocalizationUtility::class, 'translate', $url['label'], 'ats'))
-                ->setActive($isActive);
-            $menu->addMenuItem($menuItem);
-        }
-
-        $menuRegistry->addMenu($menu);
-    }
-
-    /**
-     * Testing helper class
-     *
-     * @return MenuRegistry
-     * @codeCoverageIgnore
-     */
-    public function getMenuRegistry()
-    {
-        return $this->view->getModuleTemplate()->getDocHeaderComponent()->getMenuRegistry();
-    }
 
     /**
      * Forwards to the first allowed action (since some could be disallowed by role)

--- a/Classes/Controller/Backend/StatisticsController.php
+++ b/Classes/Controller/Backend/StatisticsController.php
@@ -31,39 +31,9 @@ class StatisticsController extends AbstractBackendController
      * @var array
      */
     protected $menuUrls = [
-        ["action" => "statistics", "label" => "Statistics"],
-        ["action" => "export", "label" => "Export"],
+        'statistics' => ["action" => "statistics", "label" => "be.label.Statistics"],
+        'export' => ["action" => "export", "label" => "be.label.Export"],
     ];
-
-    /**
-     * Builds the backend docheader menu with actions
-     *
-     * @return void
-     */
-    public function buildMenu()
-    {
-
-        $menuRegistry = $this->getMenuRegistry();
-
-        $uriBuilder = $this->controllerContext->getUriBuilder();
-
-        $menu = $menuRegistry->makeMenu()
-            ->setIdentifier("actions");
-
-        foreach ($this->menuUrls as $url) {
-                $isActive = $this->request->getControllerActionName() === $url['action'] ? true : false;
-                $uri = $uriBuilder
-                    ->reset()
-                    ->uriFor($url['action'], [], $this->request->getControllerName(), null, null);
-                $menuItem = $menu->makeMenuItem()
-                    ->setHref($uri)
-                    ->setTitle($url['label'])
-                    ->setActive($isActive);
-                $menu->addMenuItem($menuItem);
-        }
-
-        $menuRegistry->addMenu($menu);
-    }
 
     /**
      * Testing helper class

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1213,6 +1213,10 @@
         <source>Female</source>
       </trans-unit>
 
+      <trans-unit id="be.label.Export">
+        <source>Export</source>
+      </trans-unit>
+
       <trans-unit id="be.label.Export.Location">
         <source>Location:</source>
       </trans-unit>


### PR DESCRIPTION
This was the cause for non-translated menu headlines.
With this fix all controllers use the same docheader menu code.

(Moved the code to AbstractBackendController, controllers without header menus skip the function completely)