### PR TITLE
[FEATURE] Add config option to use BE user credentials in mails (true by default)

### DIFF
--- a/Classes/Service/ExtconfService.php
+++ b/Classes/Service/ExtconfService.php
@@ -147,6 +147,21 @@ class ExtconfService implements SingletonInterface
     }
 
     /**
+     * Returns whether to use backend user name and mail address in emails
+     *
+     * Default return value is true to enable backwards compatibility - if the value is not set, it should still resolve to true.
+     *
+     * @return bool
+     */
+    public function getUseBackendUserCredentialsInEmails()
+    {
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ats']['emSettings']['useBackendUserCredentialsInEmails'])) {
+            return $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ats']['emSettings']['useBackendUserCredentialsInEmails'] ? true : false;
+        }
+        return true;
+    }
+
+    /**
      * Returns the default email sender name
      *
      * @return string

--- a/Classes/Service/MailService.php
+++ b/Classes/Service/MailService.php
@@ -101,11 +101,11 @@ class MailService implements SingletonInterface
      */
     public function fetchFrom($useBackendUserCredentials = true)
     {
-        if ($useBackendUserCredentials && GeneralUtility::validEmail($this->backendUser->user['email']) && !empty($this->backendUser->user['realName'])) {
+        $extconfService = ExtconfService::getInstance();
+
+        if ($extconfService->getUseBackendUserCredentialsInEmails() && $useBackendUserCredentials && GeneralUtility::validEmail($this->backendUser->user['email']) && !empty($this->backendUser->user['realName'])) {
             return [$this->backendUser->user['email'] => $this->backendUser->user['realName']];
         }
-
-        $extconfService = ExtconfService::getInstance();
 
         if (!empty($extconfService->getEmailDefaultSenderName()) && GeneralUtility::validEmail($extconfService->getEmailDefaultSenderAddress())) {
             return [$extconfService->getEmailDefaultSenderAddress() => $extconfService->getEmailDefaultSenderName()];

--- a/Tests/Unit/Service/MailServiceTest.php
+++ b/Tests/Unit/Service/MailServiceTest.php
@@ -146,13 +146,14 @@ class MailServiceTest extends UnitTestCase
      *
      * @dataProvider mailCombinations
      */
-    public function fetchesCorrectFrom($useBeUserCredentials, $backendUserRecord, $atsSystemName, $atsSystemAddress, $systemFrom, $expectedFrom)
+    public function fetchesCorrectFrom($globallyAllowUserCredentials, $useBeUserCredentials, $backendUserRecord, $atsSystemName, $atsSystemAddress, $systemFrom, $expectedFrom)
     {
         $this->backendUser->user = $backendUserRecord;
 
         $extconfService = $this->prophesize(ExtconfService::class);
         $extconfService->getEmailDefaultSenderName()->willReturn($atsSystemName);
         $extconfService->getEmailDefaultSenderAddress()->willReturn($atsSystemAddress);
+        $extconfService->getUseBackendUserCredentialsInEmails()->willReturn($globallyAllowUserCredentials);
 
         GeneralUtility::setSingletonInstance(ExtconfService::class, $extconfService->reveal());
 
@@ -172,6 +173,7 @@ class MailServiceTest extends UnitTestCase
         return [
             'backend user data allowed, backend user valid' => [
                 true,
+                true,
                 [
                     'email' => 'beuser@example.com',
                     'realName' => 'BackendUser',
@@ -182,6 +184,7 @@ class MailServiceTest extends UnitTestCase
                 ['beuser@example.com' => 'BackendUser'],
             ],
             'backend user data allowed, backend user email invalid' => [
+                true,
                 true,
                 [
                     'email' => 'invalid',
@@ -194,6 +197,7 @@ class MailServiceTest extends UnitTestCase
             ],
             'backend user data allowed, backend user name invalid' => [
                 true,
+                true,
                 [
                     'email' => 'beuser@example.com',
                     'realName' => '',
@@ -204,6 +208,7 @@ class MailServiceTest extends UnitTestCase
                 ['ats@example.com' => 'ATS'],
             ],
             'backend user data allowed, backend user email invalid, ATS email invalid' => [
+                true,
                 true,
                 [
                     'email' => 'invalid',
@@ -216,6 +221,7 @@ class MailServiceTest extends UnitTestCase
             ],
             'backend user data allowed, backend user email invalid, ATS name invalid' => [
                 true,
+                true,
                 [
                     'email' => 'invalid',
                     'realName' => 'backend user',
@@ -226,6 +232,7 @@ class MailServiceTest extends UnitTestCase
                 ['system@example.com' => 'System'],
             ],
             'backend user data allowed, backend user name invalid, ATS email invalid' => [
+                true,
                 true,
                 [
                     'email' => 'beuser@example.com',
@@ -238,6 +245,7 @@ class MailServiceTest extends UnitTestCase
             ],
             'backend user data allowed, backend user name invalid, ATS name invalid' => [
                 true,
+                true,
                 [
                     'email' => 'beuser@example.com',
                     'realName' => '',
@@ -248,6 +256,19 @@ class MailServiceTest extends UnitTestCase
                 ['system@example.com' => 'System'],
             ],
             'backend user data not allowed' => [
+                true,
+                false,
+                [
+                    'email' => 'beuser@example.com',
+                    'realName' => 'backend user',
+                ],
+                'ATS',
+                'ats@example.com',
+                ['system@example.com' => 'System'],
+                ['ats@example.com' => 'ATS'],
+            ],
+            'backend user data globally disabled' => [
+                false,
                 false,
                 [
                     'email' => 'beuser@example.com',

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -10,6 +10,9 @@ jobGroupPattern = bms_jobno_%s
 # cat=basic/enable; type=string; label=Name of the group to use as a template (you need to create a group with this name!)
 jobGroupTemplate = bms department template %s
 
+# cat=basic/enable; type=boolean; label=Use backend user credentials in emails (name and mail address)
+useBackendUserCredentialsInEmails = 1
+
 # cat=basic/enable; type=string; label=Default email sender (if empty, system settings are used)
 emailDefaultSenderName =
 


### PR DESCRIPTION
Some customers may not want to always use the system/ATS-wide email name and address when sending mails to applicants via backend.

This PR adds a config option to enable usage of backend user email addresses on a system-wide level (true by default to ensure backwards compatibility).