### PR TITLE
Prevent mail actions from being available for applications without email

### DIFF
--- a/Classes/Controller/Backend/NotificationApplicationController.php
+++ b/Classes/Controller/Backend/NotificationApplicationController.php
@@ -71,8 +71,19 @@ class NotificationApplicationController extends ApplicationController
      */
     public function newMassNotificationAction($applications, MessageInterface $message = null, $messageType = null)
     {
+        $currentApplication = $applications->current();
+
+        // If there is at least one application without email, select it as the active one
+        // so sending the mass notification via email is impossible
+        foreach ($applications as $application) {
+            if (empty($application->getEmail())) {
+                $currentApplication = $application;
+                break;
+            }
+        }
+
         if ($message == null) {
-            $message = $this->messageFactory->createMessageFromConstantType($messageType, $applications->current());
+            $message = $this->messageFactory->createMessageFromConstantType($messageType, $currentApplication);
         }
 
         $message->applyTextTemplate();

--- a/Classes/Controller/Backend/NotificationApplicationController.php
+++ b/Classes/Controller/Backend/NotificationApplicationController.php
@@ -76,7 +76,7 @@ class NotificationApplicationController extends ApplicationController
         // If there is at least one application without email, select it as the active one
         // so sending the mass notification via email is impossible
         foreach ($applications as $application) {
-            if (empty($application->getEmail())) {
+            if (empty($application->getValidEmail())) {
                 $currentApplication = $application;
                 break;
             }

--- a/Classes/Domain/Model/ApplicationB.php
+++ b/Classes/Domain/Model/ApplicationB.php
@@ -276,6 +276,14 @@ class ApplicationB extends ApplicationA
         return $this->email;
     }
 
+    public function getValidEmail()
+    {
+        if (!empty($this->email) && \TYPO3\CMS\Core\Utility\GeneralUtility::validEmail($this->email)) {
+            return $this->email;
+        }
+        return null;
+    }
+
     /**
      * @param string $email
      * @return void

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1702,8 +1702,8 @@
 			</trans-unit>
 
 			<trans-unit id="be.label.ApplicationSingle.NoEmailAddressWarning">
-				<source>This application does not include an email address, you can only create a PDF file.</source>
-				<target>In der Bewerbung wurde keine E-Mail angegeben, Ausgabe nur als PDF möglich. </target>
+				<source>This application does not include a valid email address, you can only create a PDF file.</source>
+				<target>In der Bewerbung wurde keine gültige E-Mail angegeben, Ausgabe nur als PDF möglich. </target>
 			</trans-unit>
 
 			<trans-unit id="be.label.Notification.Continue">

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1758,6 +1758,11 @@
 	      	<target>Neuer Massenbescheid</target>
 	      </trans-unit>
 
+		<trans-unit id="tx_ats.be.massNotification.selectedApplications">
+			<source>Selected applications</source>
+			<target>Ausgewählte Bewerbungen</target>
+		</trans-unit>
+
 	      <!-- Age distribution -->
 	      <trans-unit id="tx_ats.stat.age.0">
 	        <source>under 20</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1701,6 +1701,11 @@
 				<target>Anmerkung</target>
 			</trans-unit>
 
+			<trans-unit id="be.label.ApplicationSingle.NoEmailAddressWarning">
+				<source>This application does not include an email address, you can only create a PDF file.</source>
+				<target>In der Bewerbung wurde keine E-Mail angegeben, Ausgabe nur als PDF möglich. </target>
+			</trans-unit>
+
 			<trans-unit id="be.label.Notification.Continue">
 				<source>Continue</source>
 				<target>Weiter</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -995,6 +995,10 @@
       	<source>New Mass Notification</source>
       </trans-unit>
 
+      <trans-unit id="tx_ats.be.massNotification.selectedApplications">
+      	<source>Selected applications</source>
+      </trans-unit>
+
       <!-- Age distribution -->
       <trans-unit id="tx_ats.stat.age.0">
         <source>under 20</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1563,7 +1563,7 @@
 			</trans-unit>
 
 			<trans-unit id="be.label.ApplicationSingle.NoEmailAddressWarning">
-				<source>This application does not include an email address, so you can only create a PDF file.</source>
+				<source>This application does not include a valid email address, so you can only create a PDF file.</source>
 			</trans-unit>
 
 			<trans-unit id="be.label.Notification.Continue">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1558,6 +1558,10 @@
 				<source>Details</source>
 			</trans-unit>
 
+			<trans-unit id="be.label.ApplicationSingle.NoEmailAddressWarning">
+				<source>This application does not include an email address, so you can only create a PDF file.</source>
+			</trans-unit>
+
 			<trans-unit id="be.label.Notification.Continue">
 				<source>Continue</source>
 			</trans-unit>
@@ -1573,6 +1577,8 @@
 			<trans-unit id="be.label.newMassPoolMoving.status">
 				<source>Status</source>
 			</trans-unit>
+
+
 
 			<!-- FlashMessages -->
 

--- a/Resources/Private/Partials/Backend/Message/CommonFields.html
+++ b/Resources/Private/Partials/Backend/Message/CommonFields.html
@@ -2,7 +2,7 @@
 <f:form.hidden property="application" value="{message.application.uid}" />
 <f:form.hidden name="action" value="{previewAction}" />
 
-<f:if condition="{message.application.email}">
+<f:if condition="{message.application.validEmail}">
 	<f:then>
 		<div class="radio">
 		  <label>

--- a/Resources/Private/Partials/Backend/Message/CommonFields.html
+++ b/Resources/Private/Partials/Backend/Message/CommonFields.html
@@ -2,24 +2,40 @@
 <f:form.hidden property="application" value="{message.application.uid}" />
 <f:form.hidden name="action" value="{previewAction}" />
 
-<div class="radio">
-  <label>
-	<f:form.radio property="sendType" id="sendTypeMail" value="mail" />
-	<f:translate id="be.label.ApplicationSingle.Acknowledge.SendMailTo"/> {message.application.email}
-  </label>
-</div>
-<div class="radio">
-  <label>
-	<f:form.radio property="sendType" id="sendTypePdf" value="pdf" />
-	<f:translate id="be.label.ApplicationSingle.Acknowledge.CreatePdf"/>
-  </label>
-</div>
-  <f:if condition="{message.textTemplateDropdownOptions -> f:count()} > 0">
-	  <div class="form-group">
-		  <label for="textTemplate">Template</label>
-				  <f:form.select class="form-control" property="textTemplate" id="textTemplate" options="{message.textTemplateDropdownOptions}" additionalAttributes="{onchange: 'this.form.submit()'}" prependOptionLabel="---" prependOptionValue="" />
-	  </div>
-  </f:if>
+<f:if condition="{message.application.email}">
+	<f:then>
+		<div class="radio">
+		  <label>
+			<f:form.radio property="sendType" id="sendTypeMail" value="mail" />
+			<f:translate id="be.label.ApplicationSingle.Acknowledge.SendMailTo"/> {message.application.email}
+		  </label>
+		</div>
+		<div class="radio">
+		  <label>
+			<f:form.radio property="sendType" id="sendTypePdf" value="pdf" />
+			<f:translate id="be.label.ApplicationSingle.Acknowledge.CreatePdf"/>
+		  </label>
+		</div>
+	</f:then>
+	<f:else>
+		<f:be.infobox state="1" message="{f:translate(key:'be.label.ApplicationSingle.NoEmailAddressWarning', default:'This application has no mail address. You can only create PDFs.')}" />
+
+		<div class="radio">
+		  <label>
+			<f:form.radio property="sendType" id="sendTypePdf" value="pdf" checked="1" />
+			<f:translate id="be.label.ApplicationSingle.Acknowledge.CreatePdf"/>
+		  </label>
+		</div>
+	</f:else>
+</f:if>
+
+
+<f:if condition="{message.textTemplateDropdownOptions -> f:count()} > 0">
+  <div class="form-group">
+	  <label for="textTemplate">Template</label>
+			  <f:form.select class="form-control" property="textTemplate" id="textTemplate" options="{message.textTemplateDropdownOptions}" additionalAttributes="{onchange: 'this.form.submit()'}" prependOptionLabel="---" prependOptionValue="" />
+  </div>
+</f:if>
 
 <f:render partial="Backend/Message/Fields/Textfield" arguments="{
   field : 'subject',

--- a/Resources/Private/Templates/Backend/NotificationApplication/NewMassNotification.html
+++ b/Resources/Private/Templates/Backend/NotificationApplication/NewMassNotification.html
@@ -3,6 +3,14 @@
 	<f:for each="{applications}" as="application">
 		<f:form.hidden name="applications[{application.uid}]" value="{application.uid}" />
 	</f:for>
+
+	<div class="panel panel-default">
+		<div class="panel-heading"><f:translate key="tx_ats.be.massNotification.selectedApplications">Selected Applications</f:translate></div>
+		<div class="table-fit">
+			<f:render partial="Backend/Application/TableInner" arguments="{applications : applications}" />
+		</div>
+	</div>
+
 	<div class="panel panel-default">
 
 		<div class="panel-heading">


### PR DESCRIPTION
... and crashing in the result. Sending mails is now only selectable in massage actions when a mail address is present.