### PR TITLE
[BUGFIX] Use globally defined file extension list in application TCA

### DIFF
--- a/Configuration/TCA/tx_ats_domain_model_application.php
+++ b/Configuration/TCA/tx_ats_domain_model_application.php
@@ -387,7 +387,7 @@ return [
                     'tablenames' => 'tx_ats_domain_model_application',
                     'table_local' => 'sys_file',
                 ]
-            ], $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'])
+            ], $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ats']['emSettings']['fileHandling']['allowedFileExtensions'])
 
         ],
         'language_skills' => [


### PR DESCRIPTION
This change is mostly irrelevant in standalone ATS, but for the sync script it leads to skipped files if the configuration in TCA is more strict.