### PR TITLE
Custom thank you page

### DIFF
--- a/Classes/Controller/Application/AbstractApplicationController.php
+++ b/Classes/Controller/Application/AbstractApplicationController.php
@@ -8,6 +8,7 @@ namespace PAGEmachine\Ats\Controller\Application;
 
 use PAGEmachine\Ats\Property\TypeConverter\UploadedFileReferenceConverter;
 use PAGEmachine\Ats\Service\ExtconfService;
+use PAGEmachine\Ats\Service\TyposcriptService;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Controller\Exception\RequiredArgumentMissingException;
 
@@ -38,6 +39,9 @@ class AbstractApplicationController extends ActionController
      */
     public function initializeAction()
     {
+        // Merge TS and FlexForm settings
+        $this->settings = TyposcriptService::getInstance()->mergeFlexFormAndTypoScriptSettings($this->settings);
+
 
         if ($this->request->hasArgument('application')) {
             $this->setPropertyMappingConfigurationForApplication();

--- a/Classes/Controller/Application/SubmitController.php
+++ b/Classes/Controller/Application/SubmitController.php
@@ -73,7 +73,11 @@ class SubmitController extends AbstractApplicationController
             }
         }
 
-        $this->redirect("submitted", null, null, ['application' => $application]);
+        if (intval($this->settings['afterSubmitPage']) > 0) {
+            $this->redirect(null, null, null, null, intval($this->settings['afterSubmitPage']));
+        } else {
+            $this->redirect("submitted", null, null, ['application' => $application]);
+        }
     }
 
     /**

--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -6,6 +6,7 @@ namespace PAGEmachine\Ats\Controller;
  */
 
 use PAGEmachine\Ats\Domain\Model\Job;
+use PAGEmachine\Ats\Service\TyposcriptService;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
@@ -30,29 +31,7 @@ class JobController extends ActionController
     {
         parent::initializeAction();
 
-        $this->settings = $this->mergeFlexFormAndTypoScriptSettings($this->settings);
-    }
-
-    /**
-     * Merges global TypoScript and FlexForm settings depending on config (override, override of empty values).
-     *
-     * @return array
-     */
-    public function mergeFlexFormAndTypoScriptSettings($settings = [])
-    {
-        if (!empty($settings['flexForm']) && intval($settings['flexForm']['override']) == 1) {
-            $overrideSettings = $settings['flexForm'];
-
-            ArrayUtility::mergeRecursiveWithOverrule(
-                $settings,
-                $overrideSettings,
-                true,
-                (intval($overrideSettings['overrideEmptyValues']) == 1 ? true : false)
-            );
-        }
-        unset($settings['flexForm']);
-
-        return $settings;
+        $this->settings = TyposcriptService::getInstance()->mergeFlexFormAndTypoScriptSettings($this->settings);
     }
 
     /**

--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -7,7 +7,6 @@ namespace PAGEmachine\Ats\Controller;
 
 use PAGEmachine\Ats\Domain\Model\Job;
 use PAGEmachine\Ats\Service\TyposcriptService;
-use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**

--- a/Classes/Service/TyposcriptService.php
+++ b/Classes/Service/TyposcriptService.php
@@ -5,6 +5,7 @@ use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /*
  * This file is part of the PAGEmachine ATS project.
@@ -28,9 +29,9 @@ class TyposcriptService implements SingletonInterface
         return GeneralUtility::makeInstance(__CLASS__);
     }
 
-    public function __construct()
+    public function __construct(ObjectManager $objectManager = null)
     {
-        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Object\ObjectManager::class);
+        $objectManager = $objectManager ?: GeneralUtility::makeInstance(ObjectManager::class);
         $this->configurationManager = $objectManager->get(ConfigurationManagerInterface::class);
     }
 

--- a/Classes/Service/TyposcriptService.php
+++ b/Classes/Service/TyposcriptService.php
@@ -2,6 +2,7 @@
 namespace PAGEmachine\Ats\Service;
 
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
@@ -55,5 +56,27 @@ class TyposcriptService implements SingletonInterface
             ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
             'ats'
         );
+    }
+
+    /**
+     * Merges global TypoScript and FlexForm settings depending on config (override, override of empty values).
+     *
+     * @return array
+     */
+    public function mergeFlexFormAndTypoScriptSettings($settings = [])
+    {
+        if (!empty($settings['flexForm']) && intval($settings['flexForm']['override']) == 1) {
+            $overrideSettings = $settings['flexForm'];
+
+            ArrayUtility::mergeRecursiveWithOverrule(
+                $settings,
+                $overrideSettings,
+                true,
+                (intval($overrideSettings['overrideEmptyValues']) == 1 ? true : false)
+            );
+        }
+        unset($settings['flexForm']);
+
+        return $settings;
     }
 }

--- a/Configuration/FlexForms/FlexformJobs.xml
+++ b/Configuration/FlexForms/FlexformJobs.xml
@@ -76,6 +76,21 @@
                      </config>
                   </TCEforms>
                </settings.flexForm.policyPage>
+               <settings.flexForm.afterSubmitPage>
+                  <TCEforms>
+                     <label>LLL:EXT:ats/Resources/Private/Language/locallang_db.xlf:flexform.jobs.afterSubmitPage</label>
+                     <displayCond>FIELD:settings.flexForm.override:REQ:true</displayCond>
+                     <config>
+                        <type>group</type>
+                        <internal_type>db</internal_type>
+                        <allowed>pages</allowed>
+                        <size>1</size>
+                        <maxitems>1</maxitems>
+                        <minitems>0</minitems>
+                        <show_thumbs>1</show_thumbs>
+                     </config>
+                  </TCEforms>
+               </settings.flexForm.afterSubmitPage>
                <settings.flexForm.allowedStaticLanguages>
                   <TCEforms>
                      <label>LLL:EXT:ats/Resources/Private/Language/locallang_db.xlf:flexform.jobs.allowedStaticLanguages</label>
@@ -91,7 +106,6 @@
                      </config>
                   </TCEforms>
                </settings.flexForm.allowedStaticLanguages>
-               // ...
             </el>
          </ROOT>
       </sDEF>

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -24,6 +24,8 @@ plugin.tx_ats {
 		allowedStaticLanguages =
 		# cat=plugin.tx_ats/pages; type=string; label=Privacy Policy page
 		policyPage =
+		# cat=plugin.tx_ats/pages; type=string; label=Page to redirect to after submit (if empty, default text is shown)
+		afterSubmitPage =
 
 		# cat=plugin.tx_ats//enable; type=boolean; label=Render structured job definitions (JSON-LD)
 		renderStructuredJobDefinitions = 0

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -79,6 +79,7 @@ plugin.tx_ats {
 		applicationPage = {$plugin.tx_ats.settings.applicationPage}
 		feUserGroup = {$plugin.tx_ats.settings.feUserGroup}
 		policyPage = {$plugin.tx_ats.settings.policyPage}
+		afterSubmitPage = {$plugin.tx_ats.settings.afterSubmitPage}
 
 		allowedStaticLanguages = {$plugin.tx_ats.settings.allowedStaticLanguages}
 

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -398,7 +398,7 @@
 			</trans-unit>
 
 			<trans-unit id="flexform.jobs.afterSubmitPage">
-				<source>Page to redirect to after successful submit ("Thank you"-Page)</source>
+				<source>Page to redirect to after successful submit ("Thank you" page)</source>
 				<target>Seite, zu der nach dem Abschicken der Bewerbung weitergeleitet werden soll ("Danke"-Seite)</target>
 			</trans-unit>
 

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -397,6 +397,11 @@
 				<target>Datenschutzerklärungs-Seite</target>
 			</trans-unit>
 
+			<trans-unit id="flexform.jobs.afterSubmitPage">
+				<source>Page to redirect to after successful submit ("Thank you"-Page)</source>
+				<target>Seite, zu der nach dem Abschicken der Bewerbung weitergeleitet werden soll ("Danke"-Seite)</target>
+			</trans-unit>
+
 			<trans-unit id="flexform.jobs.allowedStaticLanguages">
 				<source>Allowed languages inside language dropdown</source>
 				<target>Erlaubte Sprachangaben im Sprach-Auswahlfeld</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -453,6 +453,10 @@
 				<source>Page with policy details</source>
 			</trans-unit>
 
+			<trans-unit id="flexform.jobs.afterSubmitPage">
+				<source>Page to redirect to after successful submit ("Thank you"-Page)</source>
+			</trans-unit>
+
 			<trans-unit id="flexform.jobs.allowedStaticLanguages">
 				<source>Allowed languages inside language dropdown</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -454,7 +454,7 @@
 			</trans-unit>
 
 			<trans-unit id="flexform.jobs.afterSubmitPage">
-				<source>Page to redirect to after successful submit ("Thank you"-Page)</source>
+				<source>Page to redirect to after successful submit ("Thank you" page)</source>
 			</trans-unit>
 
 			<trans-unit id="flexform.jobs.allowedStaticLanguages">

--- a/Tests/Unit/Controller/Application/AbstractApplicationControllerTest.php
+++ b/Tests/Unit/Controller/Application/AbstractApplicationControllerTest.php
@@ -11,7 +11,9 @@ use PAGEmachine\Ats\Domain\Model\Application;
 use PAGEmachine\Ats\Domain\Repository\ApplicationRepository;
 use PAGEmachine\Ats\Property\TypeConverter\UploadedFileReferenceConverter;
 use PAGEmachine\Ats\Service\AuthenticationService;
+use PAGEmachine\Ats\Service\TyposcriptService;
 use Prophecy\Argument;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\Argument as ControllerArgument;
 use TYPO3\CMS\Extbase\Mvc\Controller\Arguments;
 use TYPO3\CMS\Extbase\Mvc\Controller\Exception\RequiredArgumentMissingException;
@@ -52,10 +54,8 @@ class AbstractApplicationControllerTest extends UnitTestCase
 
         $typoscriptService = $this->prophesize(TyposcriptService::class);
         //Return orginal settings without modification
-        $typoscriptService->mergeFlexFormAndTypoScriptSettings(Argument::type("array"))->will(function($args){
-            return $args[0];
-        });
-        GeneralUtility::addSingletonInstance(TyposcriptService::class, $typoscriptService->reveal());
+        $typoscriptService->mergeFlexFormAndTypoScriptSettings(Argument::any())->willReturnArgument(0);
+        GeneralUtility::setSingletonInstance(TyposcriptService::class, $typoscriptService->reveal());
     }
 
     /**

--- a/Tests/Unit/Controller/Application/AbstractApplicationControllerTest.php
+++ b/Tests/Unit/Controller/Application/AbstractApplicationControllerTest.php
@@ -49,6 +49,13 @@ class AbstractApplicationControllerTest extends UnitTestCase
 
         $this->view = $this->prophesize(ViewInterface::class);
         $this->inject($this->controller, 'view', $this->view->reveal());
+
+        $typoscriptService = $this->prophesize(TyposcriptService::class);
+        //Return orginal settings without modification
+        $typoscriptService->mergeFlexFormAndTypoScriptSettings(Argument::type("array"))->will(function($args){
+            return $args[0];
+        });
+        GeneralUtility::addSingletonInstance(TyposcriptService::class, $typoscriptService->reveal());
     }
 
     /**

--- a/Tests/Unit/Controller/JobControllerTest.php
+++ b/Tests/Unit/Controller/JobControllerTest.php
@@ -9,6 +9,9 @@ use Nimut\TestingFramework\TestCase\UnitTestCase;
 use PAGEmachine\Ats\Controller\JobController;
 use PAGEmachine\Ats\Domain\Model\Job;
 use PAGEmachine\Ats\Domain\Repository\JobRepository;
+use PAGEmachine\Ats\Service\TyposcriptService;
+use Prophecy\Argument;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 
 /**
@@ -36,137 +39,12 @@ class JobControllerTest extends UnitTestCase
 
         $this->view = $this->prophesize(ViewInterface::class);
         $this->inject($this->controller, 'view', $this->view->reveal());
+
+        $typoscriptService = $this->prophesize(TyposcriptService::class);
+        //Return orginal settings without modification
+        $typoscriptService->mergeFlexFormAndTypoScriptSettings(Argument::any())->willReturnArgument(0);
+        GeneralUtility::setSingletonInstance(TyposcriptService::class, $typoscriptService->reveal());
     }
-
-    /**
-     * @test
-     */
-    public function mergesTSSettingsWithNonEmptyFlexSettings()
-    {
-        $settings = [
-            'foo' => 'bar',
-            'bar' => 'baz',
-            'flexForm' => [
-                'override' => '1',
-                'foo' => 'overrideBar',
-                'bar' => '',
-            ],
-        ];
-
-        $expectedSettings = [
-            'foo' => 'overrideBar',
-            'bar' => 'baz',
-            'override' => '1',
-        ];
-
-        $this->assertEquals(
-            $expectedSettings,
-            $this->controller->mergeFlexFormAndTypoScriptSettings($settings)
-        );
-    }
-
-
-    /**
-     * @test
-     */
-    public function mergesTSSettingsWithEmptyFlexSettings()
-    {
-        $settings = [
-            'foo' => 'bar',
-            'bar' => 'baz',
-            'flexForm' => [
-                'override' => '1',
-                'overrideEmptyValues' => '1',
-                'foo' => 'overrideBar',
-                'bar' => '',
-            ],
-        ];
-
-        $expectedSettings = [
-            'foo' => 'overrideBar',
-            'bar' => '',
-            'override' => '1',
-            'overrideEmptyValues' => '1',
-        ];
-
-        $this->assertEquals(
-            $expectedSettings,
-            $this->controller->mergeFlexFormAndTypoScriptSettings($settings)
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function keepsTSSettingsIfFlexformIsDisabled()
-    {
-        $settings = [
-            'foo' => 'bar',
-            'bar' => 'baz',
-            'flexForm' => [
-                'override' => '0',
-                'overrideEmptyValues' => '0',
-                'foo' => 'overrideBar',
-                'bar' => '',
-            ],
-        ];
-
-        $expectedSettings = [
-            'foo' => 'bar',
-            'bar' => 'baz',
-        ];
-
-        $this->assertEquals(
-            $expectedSettings,
-            $this->controller->mergeFlexFormAndTypoScriptSettings($settings)
-        );
-    }
-
-    // /**
-    //  * @test
-    //  * @dataProvider settings
-    //  *
-    //  * @param  string $override      Override. String since the parsed config contains an integer string such as '1'
-    //  * @param  string $overrideEmpty Override empty values. String since the parsed config contains an integer string such as '1'
-    //  * @param  array  $tsSettings    Global TS settings array
-    //  * @param  array  $flexSettings  Flexform settings array
-    //  * @param  array  $expectedResultSettings The expected result settings
-    //  * @return void
-    //  */
-    // public function mergesFlexformSettingsWithTypoScriptSettings($override, $overrideEmpty, $tsSettings = [], $flexSettings = [], $expectedResultSettings = [])
-    // {
-    //     $settings = [
-
-
-    //     ]
-
-
-    //     $this->assertEquals()
-    // }
-
-    // public function settings()
-    // {
-    //     return [
-    //         'override, ignore empty' => [
-    //             '1',
-    //             '0',
-    //             [
-    //                 'value1' => 'TS value',
-    //                 'value2' => 'TS value',
-    //             ],
-    //             [
-    //                 'value1' => 'Flex value',
-    //                 'value2' => '',
-    //             ],
-    //             [
-    //                 'value1' => 'Flex value',
-    //                 'value2' => 'TS value',
-    //             ],
-    //         ]
-
-
-    //     ];
-    // }
 
     /**
      * @test

--- a/Tests/Unit/Service/TyposcriptServiceTest.php
+++ b/Tests/Unit/Service/TyposcriptServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+namespace PAGEmachine\Ats\Tests\Unit\Service;
+
+/*
+ * This file is part of the PAGEmachine ATS project.
+ */
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use PAGEmachine\Ats\Service\TyposcriptService;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+/**
+ * Testcase for PAGEmachine\Ats\Service\TyposcriptService
+ */
+class TyposcriptServiceTest extends UnitTestCase
+{
+    /**
+     *
+     * @var TyposcriptService
+     */
+    protected $typoscriptService;
+
+
+    /**
+     * Setup
+     */
+    protected function setUp()
+    {
+        $objectManager = $this->prophesize(ObjectManager::class);
+        $objectManager->get(ConfigurationManagerInterface::class)->willReturn(new \StdClass());
+
+        $this->typoscriptService = new TyposcriptService($objectManager->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function mergesTSSettingsWithNonEmptyFlexSettings()
+    {
+        $settings = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'flexForm' => [
+                'override' => '1',
+                'foo' => 'overrideBar',
+                'bar' => '',
+            ],
+        ];
+
+        $expectedSettings = [
+            'foo' => 'overrideBar',
+            'bar' => 'baz',
+            'override' => '1',
+        ];
+
+        $this->assertEquals(
+            $expectedSettings,
+            $this->typoscriptService->mergeFlexFormAndTypoScriptSettings($settings)
+        );
+    }
+
+
+    /**
+     * @test
+     */
+    public function mergesTSSettingsWithEmptyFlexSettings()
+    {
+        $settings = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'flexForm' => [
+                'override' => '1',
+                'overrideEmptyValues' => '1',
+                'foo' => 'overrideBar',
+                'bar' => '',
+            ],
+        ];
+
+        $expectedSettings = [
+            'foo' => 'overrideBar',
+            'bar' => '',
+            'override' => '1',
+            'overrideEmptyValues' => '1',
+        ];
+
+        $this->assertEquals(
+            $expectedSettings,
+            $this->typoscriptService->mergeFlexFormAndTypoScriptSettings($settings)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function keepsTSSettingsIfFlexformIsDisabled()
+    {
+        $settings = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'flexForm' => [
+                'override' => '0',
+                'overrideEmptyValues' => '0',
+                'foo' => 'overrideBar',
+                'bar' => '',
+            ],
+        ];
+
+        $expectedSettings = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+        ];
+
+        $this->assertEquals(
+            $expectedSettings,
+            $this->typoscriptService->mergeFlexFormAndTypoScriptSettings($settings)
+        );
+    }
+}


### PR DESCRIPTION
This PR adds the config option to set a custom "thank you"-page. The applicant will be redirected to this page after successful submit.

Also, Flexform setting overrides were only applied to job list and single view, not the application form. This is also fixed in the first commit.

Please test:
- If the constant "afterSubmitPage" contains a page ID, the form will redirect to it after submit.
- Overrides via plugin Flexform settings should also work.

Checks if a page exists are intentionally left out in the redirect part. It is the job of the integrator/editor to make sure a page exists. This is what the wizards inside the plugin FlexForm are for, editors can use them if constant format is unclear.