### PR TITLE
Anonymization via Scheduler (GDPR)

### DIFF
--- a/Classes/Command/AnonymizeCommandController.php
+++ b/Classes/Command/AnonymizeCommandController.php
@@ -1,8 +1,8 @@
 <?php
 namespace Pagemachine\Ats\Command;
 
+use PAGEmachine\Ats\Service\AnonymizationService;
 use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
-use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /*
  * This file is part of the Pagemachine ATS project.
@@ -25,68 +25,11 @@ class AnonymizeCommandController extends CommandController
      */
     public function applicationsCommand()
     {
-        /**
-         * Future config vars
-         */
-        $anonymizeLimit = "90 days";
+        $this->outputLine("Starting anonymization of applications...");
 
-        $config = [
-            'title' => '*',
-            'firstname' => '*',
-            'surname' => '*',
-            'nationality' => '*',
-            'street' => '*',
-            'zipcode' => '*',
-            'city' => '*',
-            'email' => '*',
-            'phone' => '*',
-            'mobile' => '*',
-            'employed' => 0,
-            'schoolQualification' => '*',
-            'professionalQualification' => '*',
-            'professionalQualificationFinalGrade' => '*',
-            'academicDegree' => '*',
-            'academicDegreeFinalGrade' => '*',
-            'doctoralDegree' => '*',
-            'doctoralDegreeFinalGrade' => '*',
-            'previousKnowledge' => '*',
-            'itKnowledge' => '*',
-            'languageSkills' => new ObjectStorage(),
-            'comment' => '*',
-            'referrer' => '*',
-            //TODO: Languageskills?
-            //TODO: Files
-        ];
+        $anonymizationService = AnonymizationService::getInstance();
 
-
-        $threshold = new \DateTime();
-        $threshold->sub(
-            \DateInterval::createFromDateString($anonymizeLimit)
-        );
-
-        $count = $this->applicationRepository->countOldApplications($threshold);
-        $this->outputLine(sprintf('Found %s old applications for anonymization.', $count));
-
-        $counter = 0;
-
-        foreach ($this->applicationRepository->findOldApplications($threshold) as $application) {
-            foreach ($config as $property => $value) {
-                $application->_setProperty($property, $value);
-            }
-            $application->setAnonymized(true);
-            $this->applicationRepository->update($application);
-
-            $counter++;
-
-            if ($counter >= 20) {
-                $this->applicationRepository->persistAll();
-                $counter = 0;
-            }
-
-            $this->outputLine(sprintf('\tAnonymized application with uid %s.', $application->getUid()));
-        }
-
-        $this->applicationRepository->persistAll();
+        $anonymizationService->anonymize('PAGEmachine\Ats\Domain\Model\Application');
 
         $this->outputLine();
         $this->outputLine('Done.');

--- a/Classes/Command/AnonymizeCommandController.php
+++ b/Classes/Command/AnonymizeCommandController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pagemachine\Ats\Command;
 
+use PAGEmachine\Ats\Domain\Repository\ApplicationRepository;
 use PAGEmachine\Ats\Service\AnonymizationService;
 use PAGEmachine\Ats\Service\TyposcriptService;
 use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
@@ -16,10 +17,18 @@ use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
 class AnonymizeCommandController extends CommandController
 {
     /**
-     * @var \PAGEmachine\Ats\Domain\Repository\ApplicationRepository
-     * @inject
+     * @var ApplicationRepository
      */
     protected $applicationRepository;
+
+    /**
+     * @param ApplicationRepository $applicationRepository
+     * @return void
+     */
+    public function injectApplicationRepository(ApplicationRepository $applicationRepository)
+    {
+        $this->applicationRepository = $applicationRepository;
+    }
 
     /**
      * Command to anonymize applications

--- a/Classes/Command/AnonymizeCommandController.php
+++ b/Classes/Command/AnonymizeCommandController.php
@@ -2,6 +2,7 @@
 namespace Pagemachine\Ats\Command;
 
 use PAGEmachine\Ats\Service\AnonymizationService;
+use PAGEmachine\Ats\Service\TyposcriptService;
 use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
 
 /*
@@ -29,9 +30,39 @@ class AnonymizeCommandController extends CommandController
 
         $anonymizationService = AnonymizationService::getInstance();
 
-        $anonymizationService->anonymize('PAGEmachine\Ats\Domain\Model\Application');
+        $anonymizationService->anonymize(
+            'PAGEmachine\Ats\Domain\Model\Application',
+            $this->getMinimumAnonymizationAge(),
+            $this->getAnonymizationConfigurationForClassName('PAGEmachine\Ats\Domain\Model\Application')
+        );
 
         $this->outputLine();
         $this->outputLine('Done.');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMinimumAnonymizationAge()
+    {
+        $settings = TyposcriptService::getInstance()->getSettings();
+        return $settings['anonymization']['minimumAge'] ?: '120 days';
+    }
+
+    /**
+     * Fetches config for anonymization for given class
+     *
+     * @param  string $className
+     * @return array
+     */
+    protected function getAnonymizationConfigurationForClassName($className)
+    {
+        $settings = TyposcriptService::getInstance()->getSettings();
+
+        if ($settings['anonymization']['objects'][$className]) {
+            return $settings['anonymization']['objects'][$className];
+        } else {
+            throw new \PAGEmachine\Ats\Exception(sprintf('Could not find anonymization configuration for class %1$s. Check your TypoScript setup in path "module.tx_ats.anonymization.objects.%1$s.', $className), 1542970640);
+        }
     }
 }

--- a/Classes/Command/AnonymizeCommandController.php
+++ b/Classes/Command/AnonymizeCommandController.php
@@ -1,0 +1,94 @@
+<?php
+namespace Pagemachine\Ats\Command;
+
+use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+
+/*
+ * This file is part of the Pagemachine ATS project.
+ */
+
+/**
+ * Anonymize command controller
+ * Anonymizes applications and user data
+ */
+class AnonymizeCommandController extends CommandController
+{
+    /**
+     * @var \PAGEmachine\Ats\Domain\Repository\ApplicationRepository
+     * @inject
+     */
+    protected $applicationRepository;
+
+    /**
+     * Command to anonymize applications
+     */
+    public function applicationsCommand()
+    {
+        /**
+         * Future config vars
+         */
+        $anonymizeLimit = "90 days";
+
+        $config = [
+            'title' => '*',
+            'firstname' => '*',
+            'surname' => '*',
+            'nationality' => '*',
+            'street' => '*',
+            'zipcode' => '*',
+            'city' => '*',
+            'email' => '*',
+            'phone' => '*',
+            'mobile' => '*',
+            'employed' => 0,
+            'schoolQualification' => '*',
+            'professionalQualification' => '*',
+            'professionalQualificationFinalGrade' => '*',
+            'academicDegree' => '*',
+            'academicDegreeFinalGrade' => '*',
+            'doctoralDegree' => '*',
+            'doctoralDegreeFinalGrade' => '*',
+            'previousKnowledge' => '*',
+            'itKnowledge' => '*',
+            'languageSkills' => new ObjectStorage(),
+            'comment' => '*',
+            'referrer' => '*',
+            //TODO: Languageskills?
+            //TODO: Files
+        ];
+
+
+        $threshold = new \DateTime();
+        $threshold->sub(
+            \DateInterval::createFromDateString($anonymizeLimit)
+        );
+
+        $count = $this->applicationRepository->countOldApplications($threshold);
+        $this->outputLine(sprintf('Found %s old applications for anonymization.', $count));
+
+        $counter = 0;
+
+        foreach ($this->applicationRepository->findOldApplications($threshold) as $application) {
+            foreach ($config as $property => $value) {
+                $application->_setProperty($property, $value);
+            }
+            $application->setAnonymized(true);
+            $this->applicationRepository->update($application);
+
+            $counter++;
+
+            if ($counter >= 20) {
+                $this->applicationRepository->persistAll();
+                $counter = 0;
+            }
+
+            $this->outputLine(sprintf('\tAnonymized application with uid %s.', $application->getUid()));
+        }
+
+        $this->applicationRepository->persistAll();
+
+        $this->outputLine();
+        $this->outputLine('Done.');
+    }
+}

--- a/Classes/Command/ApplicationsCommandController.php
+++ b/Classes/Command/ApplicationsCommandController.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pagemachine\Ats\Command;
 
+use PAGEmachine\Ats\Domain\Model\Application;
 use PAGEmachine\Ats\Domain\Repository\ApplicationRepository;
 use PAGEmachine\Ats\Service\AnonymizationService;
 use PAGEmachine\Ats\Service\TyposcriptService;
@@ -11,10 +12,9 @@ use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
  */
 
 /**
- * Anonymize command controller
- * Anonymizes applications and user data
+ * Application related commandcontroller
  */
-class AnonymizeCommandController extends CommandController
+class ApplicationsCommandController extends CommandController
 {
     /**
      * @var ApplicationRepository
@@ -33,16 +33,16 @@ class AnonymizeCommandController extends CommandController
     /**
      * Command to anonymize applications
      */
-    public function applicationsCommand()
+    public function anonymizeCommand()
     {
         $this->outputLine("Starting anonymization of applications...");
 
         $anonymizationService = AnonymizationService::getInstance();
 
         $anonymizationService->anonymize(
-            'PAGEmachine\Ats\Domain\Model\Application',
+            Application::class,
             $this->getMinimumAnonymizationAge(),
-            $this->getAnonymizationConfigurationForClassName('PAGEmachine\Ats\Domain\Model\Application')
+            $this->getAnonymizationConfigurationForClassName(Application::class)
         );
 
         $this->outputLine();

--- a/Classes/Domain/Model/AbstractApplication.php
+++ b/Classes/Domain/Model/AbstractApplication.php
@@ -167,4 +167,26 @@ class AbstractApplication extends AbstractEntity
     {
         $this->history->detach($historyEntry);
     }
+
+    /**
+     * @var bool $anonymized
+     */
+    protected $anonymized;
+
+    /**
+     * @return bool
+     */
+    public function getAnonymized()
+    {
+        return $this->anonymized;
+    }
+
+    /**
+     * @param bool $anonymized
+     * @return void
+     */
+    public function setAnonymized($anonymized)
+    {
+        $this->anonymized = $anonymized;
+    }
 }

--- a/Classes/Domain/Repository/AbstractApplicationRepository.php
+++ b/Classes/Domain/Repository/AbstractApplicationRepository.php
@@ -105,6 +105,7 @@ class AbstractApplicationRepository extends Repository
             [
                 $query->equals("user", $user),
                 $query->equals("job", $job),
+                $query->equals('anonymized', false),
             ],
             $this->buildConstraintsForStatusRange($query, $minStatus, $maxStatus)
         );
@@ -162,7 +163,8 @@ class AbstractApplicationRepository extends Repository
 
         $constraint = $query->logicalAnd(
             $query->logicalOr($constraints),
-            $query->lessThan("status", ApplicationStatus::EMPLOYED)
+            $query->lessThan("status", ApplicationStatus::EMPLOYED),
+            $query->equals('anonymized', false)
         );
 
         return $constraint;
@@ -200,7 +202,10 @@ class AbstractApplicationRepository extends Repository
         $query = $this->createQuery();
 
         $query->matching(
-            $query->lessThan("status", ApplicationStatus::EMPLOYED)
+            $query->logicalAnd(
+                $query->equals('anonymized', false),
+                $query->lessThan("status", ApplicationStatus::EMPLOYED)
+            )
         );
 
         return $query->execute();

--- a/Classes/Domain/Repository/AnonymizationTrait.php
+++ b/Classes/Domain/Repository/AnonymizationTrait.php
@@ -18,7 +18,7 @@ trait AnonymizationTrait
      *
      * @param \DateTime $threshold The date up to which applications are "old"
      * @param array $additionalConditions
-     * @return \Generator
+     * @return \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult
      */
     public function findOldObjects(\DateTime $threshold, $additionalConditions = null)
     {

--- a/Classes/Domain/Repository/AnonymizationTrait.php
+++ b/Classes/Domain/Repository/AnonymizationTrait.php
@@ -63,10 +63,10 @@ trait AnonymizationTrait
     {
         $value = $constraintConfig['value'];
 
-        if ($constraintConfig['cast']) {
-            $castResult = settype($value, $constraintConfig['cast']);
+        if ($constraintConfig['type']) {
+            $castResult = settype($value, $constraintConfig['type']);
             if (!$castResult) {
-                throw new \Exception(sprintf('Could not cast value "%s" to type "%s"', $value, $constraintConfig['cast']));
+                throw new \Exception(sprintf('Could not cast value "%s" to type "%s"', $value, $constraintConfig['type']));
             }
         }
 

--- a/Classes/Domain/Repository/AnonymizationTrait.php
+++ b/Classes/Domain/Repository/AnonymizationTrait.php
@@ -1,6 +1,8 @@
 <?php
 namespace PAGEmachine\Ats\Domain\Repository;
 
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
 /*
  * This file is part of the PAGEmachine ATS project.
  */
@@ -11,44 +13,63 @@ namespace PAGEmachine\Ats\Domain\Repository;
 trait AnonymizationTrait
 {
     /**
-     * Counts all applications older than a given date
-     * @param  \DateTime $threshold The date up to which applications are "old"
-     * @return QueryResult
-     */
-    public function countOldObjects(\DateTime $threshold)
-    {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->logicalAnd(
-                $query->equals('anonymized', false),
-                $query->lessThan("creationDate", $threshold)
-            )
-        );
-
-        return $query->count();
-    }
-
-    /**
      * Finds all applications older than a given date
      * Fetches one application at a time to prevent too large result sets
      *
-     * @param  \DateTime $threshold The date up to which applications are "old"
+     * @param \DateTime $threshold The date up to which applications are "old"
+     * @param array $additionalConditions
      * @return \Generator
      */
-    public function findOldObjects(\DateTime $threshold)
+    public function findOldObjects(\DateTime $threshold, $additionalConditions = null)
     {
         $query = $this->createQuery();
+
+        $constraints = [
+            $query->equals('anonymized', false),
+            $query->lessThan('creationDate', $threshold),
+        ];
+
+        // Add additional conditions from config
+        $conditions = [];
+        if (!empty($additionalConditions)) {
+            foreach ($additionalConditions as $conditionConfig) {
+                $conditions[] = $this->buildConstraint($query, $conditionConfig);
+            }
+            $constraints[] = $query->logicalAnd($conditions);
+        }
+
         $query->matching(
             $query->logicalAnd(
-                $query->equals('anonymized', false),
-                $query->lessThan("creationDate", $threshold)
+                $constraints
             )
         );
+
         return $query->execute();
     }
 
     public function persistAll()
     {
         $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * Converts the given config into a query constraint
+     *
+     * @param  QueryInterface $query
+     * @param  array $constraintConfig
+     * @return ConstraintInterface
+     */
+    public function buildConstraint(QueryInterface $query, $constraintConfig)
+    {
+        $value = $constraintConfig['value'];
+
+        if ($constraintConfig['cast']) {
+            $castResult = settype($value, $constraintConfig['cast']);
+            if (!$castResult) {
+                throw new \Exception(sprintf('Could not cast value "%s" to type "%s"', $value, $constraintConfig['type']));
+            }
+        }
+
+        return $query->{$constraintConfig['operator']}($constraintConfig['property'], $value);
     }
 }

--- a/Classes/Domain/Repository/AnonymizationTrait.php
+++ b/Classes/Domain/Repository/AnonymizationTrait.php
@@ -66,7 +66,7 @@ trait AnonymizationTrait
         if ($constraintConfig['cast']) {
             $castResult = settype($value, $constraintConfig['cast']);
             if (!$castResult) {
-                throw new \Exception(sprintf('Could not cast value "%s" to type "%s"', $value, $constraintConfig['type']));
+                throw new \Exception(sprintf('Could not cast value "%s" to type "%s"', $value, $constraintConfig['cast']));
             }
         }
 

--- a/Classes/Domain/Repository/AnonymizationTrait.php
+++ b/Classes/Domain/Repository/AnonymizationTrait.php
@@ -43,12 +43,8 @@ trait AnonymizationTrait
                 $query->equals('anonymized', false),
                 $query->lessThan("creationDate", $threshold)
             )
-        )->setLimit(1);
-
-        for ($i = 0; $i < $this->countOldObjects($threshold); $i++) {
-            $query->setOffset($i);
-            yield $query->execute()->getFirst();
-        }
+        );
+        return $query->execute();
     }
 
     public function persistAll()

--- a/Classes/Domain/Repository/AnonymizationTrait.php
+++ b/Classes/Domain/Repository/AnonymizationTrait.php
@@ -1,0 +1,58 @@
+<?php
+namespace PAGEmachine\Ats\Domain\Repository;
+
+/*
+ * This file is part of the PAGEmachine ATS project.
+ */
+
+/**
+ * Trait for anonymization related calls
+ */
+trait AnonymizationTrait
+{
+    /**
+     * Counts all applications older than a given date
+     * @param  \DateTime $threshold The date up to which applications are "old"
+     * @return QueryResult
+     */
+    public function countOldObjects(\DateTime $threshold)
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('anonymized', false),
+                $query->lessThan("creationDate", $threshold)
+            )
+        );
+
+        return $query->count();
+    }
+
+    /**
+     * Finds all applications older than a given date
+     * Fetches one application at a time to prevent too large result sets
+     *
+     * @param  \DateTime $threshold The date up to which applications are "old"
+     * @return \Generator
+     */
+    public function findOldObjects(\DateTime $threshold)
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('anonymized', false),
+                $query->lessThan("creationDate", $threshold)
+            )
+        )->setLimit(1);
+
+        for ($i = 0; $i < $this->countOldObjects($threshold); $i++) {
+            $query->setOffset($i);
+            yield $query->execute()->getFirst();
+        }
+    }
+
+    public function persistAll()
+    {
+        $this->persistenceManager->persistAll();
+    }
+}

--- a/Classes/Domain/Repository/ApplicationRepository.php
+++ b/Classes/Domain/Repository/ApplicationRepository.php
@@ -15,6 +15,8 @@ use TYPO3\CMS\Extbase\Persistence\QueryInterface;
  */
 class ApplicationRepository extends AbstractApplicationRepository
 {
+    use AnonymizationTrait;
+
     /**
      * Adds the constraint for exceeded deadline
      *
@@ -225,51 +227,5 @@ class ApplicationRepository extends AbstractApplicationRepository
         );
 
         return $query->execute();
-    }
-
-    /**
-     * Counts all applications older than a given date
-     * @param  \DateTime $threshold The date up to which applications are "old"
-     * @return QueryResult
-     */
-    public function countOldApplications(\DateTime $threshold)
-    {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->logicalAnd(
-                $query->equals('anonymized', false),
-                $query->lessThan("creationDate", $threshold)
-            )
-        );
-
-        return $query->count();
-    }
-
-    /**
-     * Finds all applications older than a given date
-     * Fetches one application at a time to prevent too large result sets
-     *
-     * @param  \DateTime $threshold The date up to which applications are "old"
-     * @return \Generator
-     */
-    public function findOldApplications(\DateTime $threshold)
-    {
-        $query = $this->createQuery();
-        $query->matching(
-            $query->logicalAnd(
-                $query->equals('anonymized', false),
-                $query->lessThan("creationDate", $threshold)
-            )
-        )->setLimit(1);
-
-        for ($i = 0; $i < $this->countOldApplications($threshold); $i++) {
-            $query->setOffset($i);
-            yield $query->execute()->getFirst();
-        }
-    }
-
-    public function persistAll()
-    {
-        $this->persistenceManager->persistAll();
     }
 }

--- a/Classes/Domain/Repository/ApplicationRepository.php
+++ b/Classes/Domain/Repository/ApplicationRepository.php
@@ -74,6 +74,7 @@ class ApplicationRepository extends AbstractApplicationRepository
             $this->getDeadlineExceededConstraint($query, $deadlineTime),
             $query->greaterThan("status", ApplicationStatus::INCOMPLETE),
             $query->lessThan("status", ApplicationStatus::EMPLOYED),
+            $query->equals('anonymized', false),
         ];
 
         if ($backendUser != null) {
@@ -104,6 +105,7 @@ class ApplicationRepository extends AbstractApplicationRepository
                 $this->getDeadlineExceededConstraint($query, $deadlineTime)
             ),
             $query->equals("status", ApplicationStatus::NEW_APPLICATION),
+            $query->equals('anonymized', false),
         ];
 
         if ($backendUser != null) {
@@ -135,6 +137,7 @@ class ApplicationRepository extends AbstractApplicationRepository
             ),
             $query->greaterThan("status", ApplicationStatus::NEW_APPLICATION),
             $query->lessThan("status", ApplicationStatus::EMPLOYED),
+            $query->equals('anonymized', false),
         ];
 
         if ($backendUser != null) {
@@ -160,6 +163,7 @@ class ApplicationRepository extends AbstractApplicationRepository
 
         $constraints = [
             $query->greaterThanOrEqual("status", ApplicationStatus::EMPLOYED),
+            $query->equals('anonymized', false),
         ];
         $constraints = $this->getFilterConstraints($query, $constraints, $filter);
 
@@ -184,6 +188,7 @@ class ApplicationRepository extends AbstractApplicationRepository
         $constraints = [
             $query->greaterThanOrEqual("status", ApplicationStatus::EMPLOYED),
             $query->equals("pool", true),
+            $query->equals('anonymized', false),
         ];
 
         $constraints = $this->getFilterConstraints($query, $constraints, $filter);
@@ -211,6 +216,7 @@ class ApplicationRepository extends AbstractApplicationRepository
         $constraints = [
             $query->lessThan("status", ApplicationStatus::EMPLOYED),
             $query->logicalNot($query->equals("status", ApplicationStatus::INCOMPLETE)),
+            $query->equals('anonymized', false),
         ];
         $constraints = $this->getFilterConstraints($query, $constraints, $filter);
 

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -37,22 +37,22 @@ class AnonymizationService
     /**
      * Anonymizes records of given classname
      *
-     * @param  string $className
+     * @param string $className
+     * @param string $minimumAge
+     * @param array $config
      * @return void
      */
-    public function anonymize($className)
+    public function anonymize($className, $minimumAge, $config)
     {
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->persistenceManager = $objectManager->get(PersistenceManager::class);
 
         $threshold = new \DateTime();
         $threshold->sub(
-            \DateInterval::createFromDateString($this->getMinimumAnonymizationAge())
+            \DateInterval::createFromDateString($minimumAge)
         );
 
         $repository = $this->findRepositoryForClass($className);
-
-        $config = $this->getAnonymizationConfigurationForClassName($className);
         $counter = 0;
 
         foreach ($repository->findOldObjects($threshold) as $object) {
@@ -145,32 +145,6 @@ class AnonymizationService
             return $repository;
         } catch (UnknownObjectException $e) {
             throw new \PAGEmachine\Ats\Exception(sprintf('Repository for class %s not found. Stopping anonymization.', $className), 1542970640);
-        }
-    }
-
-    /**
-     * @return string
-     */
-    protected function getMinimumAnonymizationAge()
-    {
-        $settings = TyposcriptService::getInstance()->getSettings();
-        return $settings['anonymization']['minimumAge'] ?: '120 days';
-    }
-
-    /**
-     * Fetches config for anonymization for given class
-     *
-     * @param  string $className
-     * @return array
-     */
-    protected function getAnonymizationConfigurationForClassName($className)
-    {
-        $settings = TyposcriptService::getInstance()->getSettings();
-
-        if ($settings['anonymization']['objects'][$className]) {
-            return $settings['anonymization']['objects'][$className];
-        } else {
-            throw new \PAGEmachine\Ats\Exception(sprintf('Could not find anonymization configuration for class %1$s. Check your TypoScript setup in path "module.tx_ats.anonymization.objects.%1$s.', $className), 1542970640);
         }
     }
 }

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -1,0 +1,99 @@
+<?php
+namespace PAGEmachine\Ats\Service;
+
+use TYPO3\CMS\Core\Utility\ClassNamingUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extbase\Persistence\Exception\UnknownObjectException;
+
+/*
+ * This file is part of the PAGEmachine ATS project.
+ */
+
+class AnonymizationService
+{
+    /**
+     * @return AnonymizationService
+     */
+    public static function getInstance()
+    {
+        return GeneralUtility::makeInstance(__CLASS__);
+    }
+
+    /**
+     * Anonymizes records of given classname
+     *
+     * @param  string $className
+     * @return void
+     */
+    public function anonymize($className)
+    {
+        $threshold = new \DateTime();
+        $threshold->sub(
+            \DateInterval::createFromDateString($this->getMinimumAnonymizationAge())
+        );
+
+        $repository = $this->findRepositoryForClass($className);
+
+        $config = $this->getAnonymizationConfigurationForClassName($className);
+        $counter = 0;
+
+        foreach ($repository->findOldObjects($threshold) as $object) {
+            foreach ($config['properties'] as $property => $value) {
+                $object->_setProperty($property, $value);
+            }
+            $object->setAnonymized(true);
+            $repository->update($object);
+
+            $counter++;
+
+            if ($counter >= 20) {
+                $repository->persistAll();
+                $counter = 0;
+            }
+        }
+
+        $repository->persistAll();
+    }
+
+    /**
+     * Tries to find a repository for given classname
+     *
+     * @param  string $className
+     * @return \TYPO3\CMS\Extbase\Persistence\RepositoryInterface
+     */
+    protected function findRepositoryForClass($className)
+    {
+        try {
+            $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+            $repositoryClassName = ClassNamingUtility::translateModelNameToRepositoryName($className);
+            $repository = $objectManager->get($repositoryClassName);
+            return $repository;
+        } catch (UnknownObjectException $e) {
+            throw new \PAGEmachine\Ats\Exception(sprintf('Repository for class %s not found. Stopping anonymization.', $className), 1542970640);
+        }
+    }
+
+    protected function getMinimumAnonymizationAge()
+    {
+        $settings = TyposcriptService::getInstance()->getSettings();
+        return $settings['anonymization']['minimumAge'] ?: '120 days';
+    }
+
+    /**
+     * Fetches config for anonymization for given class
+     *
+     * @param  string $className
+     * @return array
+     */
+    protected function getAnonymizationConfigurationForClassName($className)
+    {
+        $settings = TyposcriptService::getInstance()->getSettings();
+
+        if ($settings['anonymization']['objects'][$className]) {
+            return $settings['anonymization']['objects'][$className];
+        } else {
+            throw new \PAGEmachine\Ats\Exception(sprintf('Could not find anonymization configuration for class %1$s. Check your TypoScript setup in path "module.tx_ats.anonymization.objects.%1$s.', $className), 1542970640);
+        }
+    }
+}

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -42,7 +42,7 @@ class AnonymizationService
      * @param array $config
      * @return void
      */
-    public function anonymize($className, $minimumAge, $config)
+    public function anonymize($className, $minimumAge, array $config)
     {
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->persistenceManager = $objectManager->get(PersistenceManager::class);
@@ -54,6 +54,8 @@ class AnonymizationService
 
         $repository = $this->findRepositoryForClass($className);
         $counter = 0;
+
+        $config['conditions'] = $config['conditions'] ?: [];
 
         foreach ($repository->findOldObjects($threshold, $config['conditions']) as $object) {
             $this->anonymizeObject($object, $config);

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -80,10 +80,6 @@ class AnonymizationService
      */
     protected function anonymizeObject(AbstractDomainObject $object, $config)
     {
-        if ($object->_hasProperty('anonymized')) {
-            $object->setAnonymized(true);
-        }
-
         switch ($config['mode']) {
             case self::ANONYMIZATION_MODE_ANONYMIZE:
                 foreach ($config['properties'] as $property => $value) {
@@ -101,6 +97,7 @@ class AnonymizationService
                 $this->deleteFile($object);
                 break;
         }
+
         if (!empty($config['children'])) {
             foreach ($config['children'] as $propertyName => $childConfig) {
                 $property = $object->_getProperty($propertyName);
@@ -113,6 +110,10 @@ class AnonymizationService
                     throw new IllegalObjectTypeException('Only ObjectStorages are supported for anonymization', 1542985424);
                 }
             }
+        }
+        if ($object->_hasProperty('anonymized')) {
+            $object->setAnonymized(true);
+            $this->persistenceManager->update($object);
         }
     }
 

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -1,6 +1,7 @@
 <?php
 namespace PAGEmachine\Ats\Service;
 
+use PAGEmachine\Ats\Domain\Model\FileReference;
 use TYPO3\CMS\Core\Utility\ClassNamingUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject;
@@ -18,6 +19,7 @@ class AnonymizationService
 {
     const ANONYMIZATION_MODE_ANONYMIZE = 'anonymize';
     const ANONYMIZATION_MODE_ANONYMIZE_DELETE = 'anonymize_and_delete';
+    const ANONYMIZATION_MODE_DELETE_FILES = 'delete_files';
 
     /**
      * @return AnonymizationService
@@ -93,6 +95,9 @@ class AnonymizationService
                 }
                 $this->persistenceManager->remove($object);
                 break;
+            case self::ANONYMIZATION_MODE_DELETE_FILES:
+                $this->deleteFile($object);
+                break;
         }
         if (!empty($config['children'])) {
             foreach ($config['children'] as $propertyName => $childConfig) {
@@ -106,6 +111,22 @@ class AnonymizationService
                     throw new IllegalObjectTypeException('Only ObjectStorages are supported for anonymization', 1542985424);
                 }
             }
+        }
+    }
+
+    /**
+     * Deletes the file behind given file reference.
+     * The reference itself is deleted automatically.
+     *
+     * @param  FileReference $fileReference
+     * @return void
+     */
+    protected function deleteFile(FileReference $fileReference)
+    {
+        $originalFile = $fileReference->getOriginalResource()->getOriginalFile();
+
+        if ($originalFile->exists()) {
+            $originalFile->getStorage()->deleteFile($originalFile);
         }
     }
 

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -55,7 +55,7 @@ class AnonymizationService
         $repository = $this->findRepositoryForClass($className);
         $counter = 0;
 
-        foreach ($repository->findOldObjects($threshold) as $object) {
+        foreach ($repository->findOldObjects($threshold, $config['conditions']) as $object) {
             $this->anonymizeObject($object, $config);
 
             $counter++;

--- a/Configuration/TCA/tx_ats_domain_model_application.php
+++ b/Configuration/TCA/tx_ats_domain_model_application.php
@@ -403,6 +403,11 @@ return [
                 'foreign_table' => 'tx_ats_domain_model_note',
                 'foreign_field' => 'application'
             ]
-        ]
+        ],
+        'anonymized' => [
+            'config' => [
+                'type' => 'check',
+            ],
+        ],
     ]
 ];

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -54,6 +54,9 @@ module.tx_ats.settings.anonymization {
             textLanguage = *
           }
         }
+        files {
+          mode = delete_files
+        }
       }
     }
   }

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -1,0 +1,31 @@
+module.tx_ats.settings.anonymization {
+  minimumAge = 90 days
+  objects {
+    PAGEmachine\Ats\Domain\Model\Application {
+      properties {
+        title = *
+        firstname = *
+        surname = *
+        nationality = *
+        street = *
+        zipcode = *
+        city = *
+        email = *
+        phone = *
+        mobile = *
+        employed = 0
+        schoolQualification = *
+        professionalQualification = *
+        professionalQualificationFinalGrade = *
+        academicDegree = *
+        academicDegreeFinalGrade = *
+        doctoralDegree = *
+        doctoralDegreeFinalGrade = *
+        previousKnowledge = *
+        itKnowledge = *
+        comment = *
+        referrer = *
+      }
+    }
+  }
+}

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -11,13 +11,13 @@ module.tx_ats.settings.anonymization {
           property = status
           operator = greaterThanOrEqual
           value = 100
-          cast = int
+          type = int
         }
         unpooled {
           property = pool
           operator = equals
           value = 0
-          cast = int
+          type = int
         }
       }
       properties {

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -1,5 +1,8 @@
 module.tx_ats.settings.anonymization {
+
+  # Anonymize all applications older than 90 days.
   minimumAge = 90 days
+
   objects {
     PAGEmachine\Ats\Domain\Model\Application {
       mode = anonymize

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -6,6 +6,20 @@ module.tx_ats.settings.anonymization {
   objects {
     PAGEmachine\Ats\Domain\Model\Application {
       mode = anonymize
+      conditions {
+        status {
+          property = status
+          operator = greaterThanOrEqual
+          value = 100
+          cast = int
+        }
+        unpooled {
+          property = pool
+          operator = equals
+          value = 0
+          cast = int
+        }
+      }
       properties {
         title = *
         firstname = *

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -2,6 +2,7 @@ module.tx_ats.settings.anonymization {
   minimumAge = 90 days
   objects {
     PAGEmachine\Ats\Domain\Model\Application {
+      mode = anonymize
       properties {
         title = *
         firstname = *
@@ -25,6 +26,34 @@ module.tx_ats.settings.anonymization {
         itKnowledge = *
         comment = *
         referrer = *
+      }
+      children {
+        history {
+          mode = anonymize_and_delete
+          properties {
+            subject = *
+            details = a:0:{}
+            historyData = a:0:{}
+            user = 0
+          }
+        }
+        notes {
+          mode = anonymize_and_delete
+          properties {
+            subject = *
+            details = *
+            is_internal = 0
+            user = 0
+          }
+        }
+        languageSkills {
+          mode = anonymize_and_delete
+          properties {
+            level = 0
+            language = 0
+            textLanguage = *
+          }
+        }
       }
     }
   }

--- a/Configuration/TypoScript/Backend/setup.ts
+++ b/Configuration/TypoScript/Backend/setup.ts
@@ -92,3 +92,4 @@ config.tx_extbase {
         TYPO3\CMS\Extbase\Persistence\Generic\QueryFactoryInterface.className = PAGEmachine\Ats\Persistence\Generic\QueryFactory
     }
 }
+<INCLUDE_TYPOSCRIPT: source="FILE:./anonymization.ts">

--- a/Configuration/TypoScript/Backend/setup_legacy.ts
+++ b/Configuration/TypoScript/Backend/setup_legacy.ts
@@ -93,6 +93,7 @@ module.tx_ats {
         ignoreAllEnableFieldsInBe = true
     }
 }
+<INCLUDE_TYPOSCRIPT: source="FILE:./anonymization.ts">
 
 config.tx_extbase {
     persistence {

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -115,5 +115,17 @@ You can configure how file uploads in the application form should behave. The op
 
 Configuration options can be found in the extension manager settings (tab *Advanced*).
 
+Anonymization
+-------------
+
+The extension provides a scheduler command for automatic anonymization of applications (GDPR!), depending on their age (configurable).
+
+The default configuration can be found inside ``Configuration/TypoScript/Backend/anonymization.ts``.
+
+You can also customize the exact behaviour for applications and their child records.
+
+- **mode** defines the exact anonymization behaviour: Either *anonymize*, *anonymize_and_delete* or *delete_files* for file references.
+- Inside **properties** you can define the replacement value for each property. Default is "*".
+- If you want to keep a property or child as it is, simply remove the value or child section.
 
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -146,14 +146,14 @@ Inside your ``ext_typoscript_setup.txt``:
                 property = status
                 operator = greaterThanOrEqual
                 value = 110
-                cast = int
+                type = int
               }
             }
          }
       }
    }
 
-Please note that the *cast* option is not always necessary, but cleaner if the value is not a string.
+Please note that the *type* option is not always necessary, but cleaner if the value is not a string.
 If you want to pass on a boolean, use 0 or 1 and cast to "bool".
 
 Also, the logic can only handle operators which require one value. Multivalued operators (in, between...) are currently not supported. Use multiple conditions for that.

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -128,4 +128,36 @@ You can also customize the exact behaviour for applications and their child reco
 - Inside **properties** you can define the replacement value for each property. Default is "*".
 - If you want to keep a property or child as it is, simply remove the value or child section.
 
+Custom conditions
+^^^^^^^^^^^^^^^^^
+
+If you have custom conditions for anonymization, there is a subkey `conditions` inside the configuration for just that.
+These conditions are appended to the general query. They use extbase query logic ("equals", "greaterThan"...).
+
+**Example**: By default only applications with status 100 (employed) or higher are anonymized. Let's say you want to change this to 110 (cancelled) instead.
+
+Inside your ``ext_typoscript_setup.txt``:
+::
+   module.tx_ats.settings.anonymization {
+      objects {
+         PAGEmachine\Ats\Domain\Model\Application {
+            conditions {
+              status {
+                property = status
+                operator = greaterThanOrEqual
+                value = 110
+                cast = int
+              }
+            }
+         }
+      }
+   }
+
+Please note that the *cast* option is not always necessary, but cleaner if the value is not a string.
+If you want to pass on a boolean, use 0 or 1 and cast to "bool".
+
+Also, the logic can only handle operators which require one value. Multivalued operators (in, between...) are currently not supported. Use multiple conditions for that.
+
+
+
 

--- a/Tests/Unit/Domain/Repository/AbstractApplicationRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/AbstractApplicationRepositoryTest.php
@@ -111,9 +111,10 @@ class AbstractApplicationRepositoryTest extends UnitTestCase
 
 
         $this->query->matching("logicalAndExpression")->willReturn($this->query->reveal());
-        $this->query->logicalAnd(["Comparison", "Comparison", "Comparison", "Comparison"])->willReturn("logicalAndExpression");
+        $this->query->logicalAnd(["Comparison", "Comparison", "Comparison", "Comparison", "Comparison"])->willReturn("logicalAndExpression");
         $this->query->equals("job", $job->reveal())->willReturn("Comparison");
         $this->query->equals("user", $user->reveal())->willReturn("Comparison");
+        $this->query->equals("anonymized", false)->willReturn("Comparison");
         $this->query->greaterThanOrEqual("status", 10)->willReturn("Comparison");
         $this->query->lessThanOrEqual("status", 50)->willReturn("Comparison");
 
@@ -183,9 +184,10 @@ class AbstractApplicationRepositoryTest extends UnitTestCase
         $this->query->contains("job.officials", 3)->shouldBeCalled()->willReturn("group2officials");
         $this->query->contains("job.contributors", 3)->shouldBeCalled()->willReturn("group2contributors");
         $this->query->lessThan("status", 100)->shouldBeCalled()->willReturn("statusless");
+        $this->query->equals("anonymized", false)->shouldBeCalled()->willReturn("non-anonymized");
 
         $this->query->logicalOr(Argument::size(7))->shouldBeCalled()->willReturn("logicalor");
-        $this->query->logicalAnd("logicalor", "statusless")->shouldBeCalled()->willReturn("matching");
+        $this->query->logicalAnd("logicalor", "statusless", "non-anonymized")->shouldBeCalled()->willReturn("matching");
         $this->query->matching("matching")->shouldBeCalled();
 
         $this->query->execute()->willReturn("something");

--- a/Tests/Unit/Domain/Repository/AnonymizationTraitTest.php
+++ b/Tests/Unit/Domain/Repository/AnonymizationTraitTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace PAGEmachine\Ats\Tests\Unit\Domain\Repository;
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use PAGEmachine\Ats\Domain\Repository\AnonymizationTrait;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+
+/**
+ * Testcase for AnonymizationTrait
+ */
+class AnonymizationTraitTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function buildsQueryConstraintsforAnonymization()
+    {
+        $query = $this->prophesize(QueryInterface::class);
+
+        $anonymizationTrait = $this->getMockForTrait(AnonymizationTrait::class);
+        $config = [
+            'property' => 'foobar',
+            'operator' => 'greaterThan',
+            'value' => '123',
+            'cast' => 'int',
+        ];
+
+        $query->greaterThan('foobar', 123)->shouldBeCalled();
+
+        $anonymizationTrait->buildConstraint($query->reveal(), $config);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,10 +25,10 @@ defined('TYPO3_MODE') or die();
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['FileDumpEID.php']['checkFileAccess']['ats_protection'] = \PAGEmachine\Ats\Hook\FileDumpControllerHook::class;
 
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \PAGEmachine\Ats\Command\ApplicationsCommandController::class;
+
 if (TYPO3_MODE === 'BE') {
     $GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['ats'] = \PAGEmachine\Ats\Hook\DataHandlerJobGroups::class;
-
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \PAGEmachine\Ats\Command\ApplicationsCommandController::class;
 }
 /**
  * ATS extension configuration

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -28,7 +28,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['FileDumpEID.php']['checkFileAccess'][
 if (TYPO3_MODE === 'BE') {
     $GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['ats'] = \PAGEmachine\Ats\Hook\DataHandlerJobGroups::class;
 
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \PAGEmachine\Ats\Command\AnonymizeCommandController::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \PAGEmachine\Ats\Command\ApplicationsCommandController::class;
 }
 /**
  * ATS extension configuration

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,6 +27,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['FileDumpEID.php']['checkFileAccess'][
 
 if (TYPO3_MODE === 'BE') {
     $GLOBALS ['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['ats'] = \PAGEmachine\Ats\Hook\DataHandlerJobGroups::class;
+
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = \PAGEmachine\Ats\Command\AnonymizeCommandController::class;
 }
 /**
  * ATS extension configuration

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -168,6 +168,8 @@ CREATE TABLE tx_ats_domain_model_application (
   notes int(11) unsigned DEFAULT '0' NOT NULL,
   history int(11) unsigned DEFAULT '0' NOT NULL,
 
+  anonymized tinyint(4) unsigned DEFAULT '0' NOT NULL,
+
 	t3ver_oid int(11) DEFAULT '0' NOT NULL,
 	t3ver_id int(11) DEFAULT '0' NOT NULL,
 	t3ver_wsid int(11) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
This PR adds a new command which anonymizes applications.
Anonymization format, minimum age and conditions  can be configured via TypoScript (see anonymization.ts and documentation for details).

The default configuration anonymizes applications  if they are **archived**, **unpooled** and **older than 90 days** (creation date). It also anonymizes all their appended children (notes, history...) and deletes associated files.
