### PR TITLE
Improve language selects

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -516,6 +516,11 @@
 				<target>Sonstige</target>
 			</trans-unit>
 
+			<trans-unit id="tx_ats.select.placeholder">
+				<source>Select</source>
+				<target>Bitte wählen</target>
+			</trans-unit>
+
 			 <!-- Frontend errors -->
 
 			<trans-unit id="tx_ats.error.intro">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -377,6 +377,10 @@
 		<source>Others</source>
 	  </trans-unit>
 
+	<trans-unit id="tx_ats.select.placeholder">
+		<source>Select</source>
+	</trans-unit>
+
 	  <!-- Frontend errors -->
 
 	  <trans-unit id="tx_ats.error.intro">

--- a/Resources/Private/Partials/Application/Field/Language.html
+++ b/Resources/Private/Partials/Application/Field/Language.html
@@ -67,7 +67,7 @@
 					<f:if condition="{settings.validation.languageSkills}">
 						<f:if condition="{application.languageSkills}">
 							<f:else>
-								<f:render section="languagerow" arguments="{languageID : placeholderIndex}" />
+								<f:render section="languagerow" arguments="{languageOffset : placeholderIndex}" />
 							</f:else>
 						</f:if>
 					</f:if>
@@ -87,7 +87,7 @@
 			</div>
 
 			<f:comment>Template rendering</f:comment>
-			<f:render section="languagerow" arguments="{languageID : newLanguageIndex, class: 'tx-ats-addlanguage'}" />
+			<f:render section="languagerow" arguments="{languageOffset : newLanguageIndex, class: 'tx-ats-addlanguage'}" />
 
 
 		</div>
@@ -106,25 +106,25 @@
 
 
 <f:section name="languagerow">
-		<div class="{class} languagebox row" data-language="{languageID}">
+		<div class="{class} languagebox row" data-language="{languageOffset}">
 
 			<div class="col-sm-3">
 					<label><f:translate key="tx_ats.languageskill.language" /></label>
-					<s:form.select class="language-select form-control" property="languageSkills.{languageID}.language" staticInfoTable="language" options="{}" prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
+					<s:form.select class="language-select form-control" property="languageSkills.{languageOffset}.language" staticInfoTable="language" options="{}" prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 			</div>
 
 			<div class="col-sm-3">
 				<label><f:translate key="tx_ats.languageskill.textLanguage" /></label>
-				<f:form.textfield class="textlanguage form-control" property="languageSkills.{languageID}.textLanguage" />
+				<f:form.textfield class="textlanguage form-control" property="languageSkills.{languageOffset}.textLanguage" />
 			</div>
 
 			<div class="col-sm-3">
 				<label><f:translate key="tx_ats.languageskill.level" /></label>
-				<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.{languageID}.level"  prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
+				<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.{languageOffset}.level"  prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 			</div>
 
 			<div class="col-sm-3">
-				<span class="btn btn-danger btn-xs remove-button" data-action="removeLanguage" data-language="{languageID}">
+				<span class="btn btn-danger btn-xs remove-button" data-action="removeLanguage" data-language="{languageOffset}">
 					<span class="glyphicon glyphicon-trash"></span>
 					<f:translate key="tx_ats.languageskill.rmLanguage">Remove</f:translate>
 				</span>

--- a/Resources/Private/Partials/Application/Field/Language.html
+++ b/Resources/Private/Partials/Application/Field/Language.html
@@ -62,6 +62,15 @@
 
 					</f:for>
 
+					<f:comment>Add one language form if languages are mandatory and no languages are given yet</f:comment>
+					<f:if condition="{settings.validation.languageSkills}">
+						<f:if condition="{application.languageSkills}">
+							<f:else>
+								<f:render section="languagerow" arguments="{languageID : 998}" />
+							</f:else>
+						</f:if>
+					</f:if>
+
 					<f:form.validationResults for="application.languageSkills">
 						<f:if condition="{validationResults.errors}">
 						<div class="row">
@@ -77,6 +86,11 @@
 			</div>
 
 
+
+			<f:comment>Template rendering</f:comment>
+			<f:render section="languagerow" arguments="{languageID : 999, class: 'tx-ats-addlanguage'}" />
+
+
 		</div>
 
 		<div class="form-group row">
@@ -89,29 +103,34 @@
 		</div>
 
 
-		<div class="tx-ats-addlanguage languagebox row" data-language="999">
+
+
+	</fieldset>
+
+
+<f:section name="languagerow">
+		<div class="{class} languagebox row" data-language="{languageID}">
 
 			<div class="col-sm-3">
 					<label><f:translate key="tx_ats.languageskill.language" /></label>
-					<s:form.select class="language-select form-control" property="languageSkills.999.language" staticInfoTable="language" options="{}" prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
+					<s:form.select class="language-select form-control" property="languageSkills.{languageID}.language" staticInfoTable="language" options="{}" prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 			</div>
 
 			<div class="col-sm-3">
 				<label><f:translate key="tx_ats.languageskill.textLanguage" /></label>
-				<f:form.textfield class="textlanguage form-control" property="languageSkills.999.textLanguage" />
+				<f:form.textfield class="textlanguage form-control" property="languageSkills.{languageID}.textLanguage" />
 			</div>
 
 			<div class="col-sm-3">
 				<label><f:translate key="tx_ats.languageskill.level" /></label>
-				<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.999.level"  prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
+				<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.{languageID}.level"  prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 			</div>
 
 			<div class="col-sm-3">
-				<span class="btn btn-danger btn-xs remove-button" data-action="removeLanguage" data-language="999">
+				<span class="btn btn-danger btn-xs remove-button" data-action="removeLanguage" data-language="{languageID}">
 					<span class="glyphicon glyphicon-trash"></span>
 					<f:translate key="tx_ats.languageskill.rmLanguage">Remove</f:translate>
 				</span>
 			</div>
 		</div>
-
-	</fieldset>
+</f:section>

--- a/Resources/Private/Partials/Application/Field/Language.html
+++ b/Resources/Private/Partials/Application/Field/Language.html
@@ -1,5 +1,6 @@
 {namespace s=SJBR\StaticInfoTables\ViewHelpers}
 {namespace ats=PAGEmachine\Ats\ViewHelpers}
+<f:alias map="{placeholderIndex: 998, newLanguageIndex: 999}">
 	<fieldset id="tx-ats-languageform">
 		<div class="form-group row">
 			<div class="col-sm-3">
@@ -66,7 +67,7 @@
 					<f:if condition="{settings.validation.languageSkills}">
 						<f:if condition="{application.languageSkills}">
 							<f:else>
-								<f:render section="languagerow" arguments="{languageID : 998}" />
+								<f:render section="languagerow" arguments="{languageID : placeholderIndex}" />
 							</f:else>
 						</f:if>
 					</f:if>
@@ -85,10 +86,8 @@
 
 			</div>
 
-
-
 			<f:comment>Template rendering</f:comment>
-			<f:render section="languagerow" arguments="{languageID : 999, class: 'tx-ats-addlanguage'}" />
+			<f:render section="languagerow" arguments="{languageID : newLanguageIndex, class: 'tx-ats-addlanguage'}" />
 
 
 		</div>
@@ -102,10 +101,8 @@
 			</div>
 		</div>
 
-
-
-
 	</fieldset>
+</f:alias>
 
 
 <f:section name="languagerow">

--- a/Resources/Private/Partials/Application/Field/Language.html
+++ b/Resources/Private/Partials/Application/Field/Language.html
@@ -21,7 +21,7 @@
 							<f:form.validationResults for="application.languageSkills.{key}.language">
 								<div class="col-sm-3 {f:if(condition:validationResults.flattenedErrors, then:'has-error')}">
 									<label><f:translate key="tx_ats.languageskill.language" /></label>
-									<s:form.select class="language-select form-control" property="languageSkills.{i.index}.language" staticInfoTable="language" options="{}" prependOptionLabel="--select--" prependOptionValue="" />
+									<s:form.select class="language-select form-control" property="languageSkills.{i.index}.language" staticInfoTable="language" options="{}" prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 								</div>
 
 
@@ -35,7 +35,7 @@
 							<f:form.validationResults for="application.languageSkills.{key}.level">
 								<div class="col-sm-3 {f:if(condition:validationResults.flattenedErrors, then:'has-error')}">
 									<label><f:translate key="tx_ats.languageskill.level" /></label>
-									<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.{i.index}.level"  prependOptionLabel="--select--" prependOptionValue="" />
+									<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.{i.index}.level"  prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 								</div>
 							</f:form.validationResults>
 
@@ -93,7 +93,7 @@
 
 			<div class="col-sm-3">
 					<label><f:translate key="tx_ats.languageskill.language" /></label>
-					<s:form.select class="language-select form-control" property="languageSkills.999.language" staticInfoTable="language" options="{}" prependOptionLabel="--select--" prependOptionValue="" />
+					<s:form.select class="language-select form-control" property="languageSkills.999.language" staticInfoTable="language" options="{}" prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 			</div>
 
 			<div class="col-sm-3">
@@ -103,7 +103,7 @@
 
 			<div class="col-sm-3">
 				<label><f:translate key="tx_ats.languageskill.level" /></label>
-				<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.999.level"  prependOptionLabel="--select--" prependOptionValue="" />
+				<ats:form.translatableSelect class="level-select form-control" translationPrefix="tx_ats.languageskill.level." options="{1:1, 2:2, 3:3, 4:4}" property="languageSkills.999.level"  prependOptionLabel="{f:translate(key:'tx_ats.select.placeholder')}" prependOptionValue="" />
 			</div>
 
 			<div class="col-sm-3">


### PR DESCRIPTION
- Translate language dropdown default ("select")
- Present one (empty) language form if languages are mandatory (so users do not have to click "add" for the mandatory language entry)