### PR TITLE
Multiple anonymization presets for archived and pooled applications

### DIFF
--- a/Classes/Command/ApplicationsCommandController.php
+++ b/Classes/Command/ApplicationsCommandController.php
@@ -34,9 +34,9 @@ class ApplicationsCommandController extends CommandController
 
     /**
      * Command to anonymize applications
-     * @param string $preset The configuration preset to use, see TS: module.tx_ats.settings.anonymization.[className].[preset]
+     * @param string $preset The configuration preset to use, see TS: module.tx_ats.settings.anonymization.[className].[preset]. Defaults: "archived" or "pooled".
      */
-    public function anonymizeCommand($preset = "default")
+    public function anonymizeCommand($preset = "archived")
     {
         $this->outputLine("Starting anonymization of applications...");
 

--- a/Classes/Command/ApplicationsCommandController.php
+++ b/Classes/Command/ApplicationsCommandController.php
@@ -34,8 +34,9 @@ class ApplicationsCommandController extends CommandController
 
     /**
      * Command to anonymize applications
+     * @param string $preset The configuration preset to use, see TS: module.tx_ats.settings.anonymization.[className].[preset]
      */
-    public function anonymizeCommand()
+    public function anonymizeCommand($preset = "default")
     {
         $this->outputLine("Starting anonymization of applications...");
 
@@ -43,8 +44,7 @@ class ApplicationsCommandController extends CommandController
 
         $anonymizationService->anonymize(
             Application::class,
-            $this->getMinimumAnonymizationAge(),
-            $this->getAnonymizationConfigurationForClassName(Application::class)
+            $this->getAnonymizationConfigurationForClassName(Application::class, $preset)
         );
 
         $this->outputLine();
@@ -74,15 +74,6 @@ class ApplicationsCommandController extends CommandController
     /**
      * @return string
      */
-    protected function getMinimumAnonymizationAge()
-    {
-        $settings = TyposcriptService::getInstance()->getSettings();
-        return $settings['anonymization']['minimumAge'] ?: '120 days';
-    }
-
-    /**
-     * @return string
-     */
     protected function getMinimumApplicationCleanupAge()
     {
         $settings = TyposcriptService::getInstance()->getSettings();
@@ -92,17 +83,18 @@ class ApplicationsCommandController extends CommandController
     /**
      * Fetches config for anonymization for given class
      *
-     * @param  string $className
+     * @param string $className
+     * @param string $preset
      * @return array
      */
-    protected function getAnonymizationConfigurationForClassName($className)
+    protected function getAnonymizationConfigurationForClassName($className, $preset)
     {
         $settings = TyposcriptService::getInstance()->getSettings();
 
-        if ($settings['anonymization']['objects'][$className]) {
-            return $settings['anonymization']['objects'][$className];
+        if ($settings['anonymization']['objects'][$className][$preset]) {
+            return $settings['anonymization']['objects'][$className][$preset];
         } else {
-            throw new \PAGEmachine\Ats\Exception(sprintf('Could not find anonymization configuration for class %1$s. Check your TypoScript setup in path "module.tx_ats.anonymization.objects.%1$s.', $className), 1542970640);
+            throw new \PAGEmachine\Ats\Exception(sprintf('Could not find anonymization configuration for class %1$s and preset "%2s". Check your TypoScript setup in path "module.tx_ats.anonymization.objects.%1$s.%2s".', $className, $preset), 1542970640);
         }
     }
 }

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -38,18 +38,17 @@ class AnonymizationService
      * Anonymizes records of given classname
      *
      * @param string $className
-     * @param string $minimumAge
      * @param array $config
      * @return void
      */
-    public function anonymize($className, $minimumAge, array $config)
+    public function anonymize($className, array $config)
     {
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $this->persistenceManager = $objectManager->get(PersistenceManager::class);
 
         $threshold = new \DateTime();
         $threshold->sub(
-            \DateInterval::createFromDateString($minimumAge)
+            \DateInterval::createFromDateString($config['minimumAge'])
         );
 
         $repository = $this->findRepositoryForClass($className);
@@ -107,7 +106,7 @@ class AnonymizationService
                         $this->anonymizeObject($child, $childConfig);
                     }
                 } else {
-                    throw new IllegalObjectTypeException('Only ObjectStorages are supported for anonymization', 1542985424);
+                    throw new IllegalObjectTypeException('Only ObjectStorages, DomainObjects and FileReferences are supported for anonymization.', 1542985424);
                 }
             }
         }

--- a/Classes/Service/AnonymizationService.php
+++ b/Classes/Service/AnonymizationService.php
@@ -106,7 +106,7 @@ class AnonymizationService
                         $this->anonymizeObject($child, $childConfig);
                     }
                 } else {
-                    throw new IllegalObjectTypeException('Only ObjectStorages, DomainObjects and FileReferences are supported for anonymization.', 1542985424);
+                    throw new IllegalObjectTypeException('Only ObjectStorages are supported for child anonymization.', 1542985424);
                 }
             }
         }

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -1,78 +1,79 @@
 module.tx_ats.settings.anonymization {
-
-  # Anonymize all applications older than 90 days.
-  minimumAge = 90 days
-
   objects {
     PAGEmachine\Ats\Domain\Model\Application {
-      mode = anonymize
-      conditions {
-        status {
-          property = status
-          operator = greaterThanOrEqual
-          value = 100
-          type = int
-        }
-        unpooled {
-          property = pool
-          operator = equals
-          value = 0
-          type = int
-        }
-      }
-      properties {
-        title = *
-        firstname = *
-        surname = *
-        nationality = *
-        street = *
-        zipcode = *
-        city = *
-        email = *
-        phone = *
-        mobile = *
-        employed = 0
-        schoolQualification = *
-        professionalQualification = *
-        professionalQualificationFinalGrade = *
-        academicDegree = *
-        academicDegreeFinalGrade = *
-        doctoralDegree = *
-        doctoralDegreeFinalGrade = *
-        previousKnowledge = *
-        itKnowledge = *
-        comment = *
-        referrer = *
-      }
-      children {
-        history {
-          mode = anonymize_and_delete
-          properties {
-            subject = *
-            details = a:0:{}
-            historyData = a:0:{}
-            user = 0
+      # Default anonymization setup and conditions. You can add your own setups if necessary.
+      default {
+        mode = anonymize
+        # Anonymize all applications older than 90 days.
+        minimumAge = 90 days
+        conditions {
+          status {
+            property = status
+            operator = greaterThanOrEqual
+            value = 100
+            type = int
+          }
+          unpooled {
+            property = pool
+            operator = equals
+            value = 0
+            type = int
           }
         }
-        notes {
-          mode = anonymize_and_delete
-          properties {
-            subject = *
-            details = *
-            is_internal = 0
-            user = 0
-          }
+        properties {
+          title = *
+          firstname = *
+          surname = *
+          nationality = *
+          street = *
+          zipcode = *
+          city = *
+          email = *
+          phone = *
+          mobile = *
+          employed = 0
+          schoolQualification = *
+          professionalQualification = *
+          professionalQualificationFinalGrade = *
+          academicDegree = *
+          academicDegreeFinalGrade = *
+          doctoralDegree = *
+          doctoralDegreeFinalGrade = *
+          previousKnowledge = *
+          itKnowledge = *
+          comment = *
+          referrer = *
         }
-        languageSkills {
-          mode = anonymize_and_delete
-          properties {
-            level = 0
-            language = 0
-            textLanguage = *
+        children {
+          history {
+            mode = anonymize_and_delete
+            properties {
+              subject = *
+              details = a:0:{}
+              historyData = a:0:{}
+              user = 0
+            }
           }
-        }
-        files {
-          mode = delete_files
+          notes {
+            mode = anonymize_and_delete
+            properties {
+              subject = *
+              details = *
+              is_internal = 0
+              user = 0
+            }
+          }
+          languageSkills {
+            mode = anonymize_and_delete
+            properties {
+              level = 0
+              language = 0
+              textLanguage = *
+            }
+          }
+          files {
+            mode = delete_files
+          }
         }
       }
     }

--- a/Configuration/TypoScript/Backend/anonymization.ts
+++ b/Configuration/TypoScript/Backend/anonymization.ts
@@ -1,25 +1,9 @@
 module.tx_ats.settings.anonymization {
   objects {
     PAGEmachine\Ats\Domain\Model\Application {
-      # Default anonymization setup and conditions. You can add your own setups if necessary.
-      default {
+      # Default setup for fields and children, do not use by its own. Can be used as a template for custom setups.
+      _default {
         mode = anonymize
-        # Anonymize all applications older than 90 days.
-        minimumAge = 90 days
-        conditions {
-          status {
-            property = status
-            operator = greaterThanOrEqual
-            value = 100
-            type = int
-          }
-          unpooled {
-            property = pool
-            operator = equals
-            value = 0
-            type = int
-          }
-        }
         properties {
           title = *
           firstname = *
@@ -73,6 +57,45 @@ module.tx_ats.settings.anonymization {
           }
           files {
             mode = delete_files
+          }
+        }
+      }
+
+      # Default anonymization setup and conditions for archived applications.
+      archived < ._default
+      archived {
+        minimumAge = 90 days
+        conditions {
+          status {
+            property = status
+            operator = greaterThanOrEqual
+            value = 100
+            type = int
+          }
+          unpooled {
+            property = pool
+            operator = equals
+            value = 0
+            type = int
+          }
+        }
+      }
+      # Second default setup for pooled applications which should be kept longer (1 year by default)
+      pooled < ._default
+      pooled {
+        minimumAge = 1 year
+        conditions {
+          status {
+            property = status
+            operator = greaterThanOrEqual
+            value = 100
+            type = int
+          }
+          pooled {
+            property = pool
+            operator = equals
+            value = 1
+            type = int
           }
         }
       }

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -88,6 +88,8 @@ If your scheduler is correctly set up, it should now anonymize all old applicati
 Custom presets
 ^^^^^^^^^^^^^^^^^
 
+**Note: The configuration part for anonymization has changed from version 1.12.1 to 1.13.0 (moving the configuration into preset sub-configuration). If your instance includes custom changes, you need to move them to the corresponding preset (archived).**
+
 The default configuration presets can be found inside ``Configuration/TypoScript/Backend/anonymization.ts``.
 
 You can also customize the exact behaviour for applications and their child records by creating your own preset.

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -66,36 +66,55 @@ This is why ATS provides tools in form of console/scheduler commands which do th
 
 The command *applications:anonymize* is a script which anonymizes applications (fills them with an asterisk in all person-related fields) and deletes all relations and files associated to them.
 
-The default configuration can be found inside ``Configuration/TypoScript/Backend/anonymization.ts``.
+**By default applications in closed status (>=100) which are older than 90 days (not pooled) or older than 1 year (in pool) are subject to anonymization.** They must be triggered f.ex. via scheduler, see below.
 
-You can also customize the exact behaviour for applications and their child records.
+Creating the default scheduler tasks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default anonymization setup consists of two separate presets, one for archived applications and one for pooled applications.
+
+You have to create a scheduler task for each of these presets. Step by step:
+
+- Create a new scheduler task and select "Extbase CommandController Task" in the "Class" selectbox.
+- Scroll down to "CommandController Command" and select "Ats Applications:anonymize".
+- Set a frequency and a start time (recommended is once every night). Save the form.
+- Scroll down again, now there is a new text field called "preset". Type in "archived". Save the form.
+
+Now create another task for pooled applications, repeat all steps.
+Set a slightly different start time so the tasks do not interfere. Enter "pooled" inside the "preset" field.
+
+If your scheduler is correctly set up, it should now anonymize all old applications in the specified intervals.
+
+Custom presets
+^^^^^^^^^^^^^^^^^
+
+The default configuration presets can be found inside ``Configuration/TypoScript/Backend/anonymization.ts``.
+
+You can also customize the exact behaviour for applications and their child records by creating your own preset.
 
 - **mode** defines the exact anonymization behaviour: Either *anonymize*, *anonymize_and_delete* or *delete_files* for file references.
 - Inside **properties** you can define the replacement value for each property. Default is "*".
 - If you want to keep a property or child as it is, simply remove the value or child section.
 
-**By default applications in closed status (>=100) which are older than 90 days and not pooled are subject to anonymization.**
-
-Custom conditions
-^^^^^^^^^^^^^^^^^
-
 If you have custom conditions for anonymization, there is a subkey `conditions` inside the configuration for just that.
 These conditions are appended to the general query. They use extbase query logic ("equals", "greaterThan"...).
 
-**Example**: By default only applications with status 100 (employed) or higher are anonymized. Let's say you want to change this to 110 (cancelled) instead.
+**Example**: By default only applications with status 100 (employed) or higher are anonymized. Let's say you want to change this to 110 (cancelled) instead for the "archived" preset.
 
 Inside your ``ext_typoscript_setup.txt``:
 ::
    module.tx_ats.settings.anonymization {
       objects {
          PAGEmachine\Ats\Domain\Model\Application {
-            conditions {
-              status {
-                property = status
-                operator = greaterThanOrEqual
-                value = 110
-                type = int
-              }
+            archived {
+               conditions {
+                 status {
+                   property = status
+                   operator = greaterThanOrEqual
+                   value = 110
+                   type = int
+                 }
+               }
             }
          }
       }


### PR DESCRIPTION
This PR changes the anonymization config structure to hold multiple "presets" which can be selected in the command/scheduler task.

This allows for different conditions and field configs targeting the same object type.

Also, two default presets are now available:
- Archived: Anonymizes archived applications (not in pool) after 3 months
- Pooled: Anonymizes archived applications kept in the pool after 1 year