### PR TITLE
[BUGFIX] Default rating option is not properly registered

### DIFF
--- a/Classes/Application/ApplicationRating.php
+++ b/Classes/Application/ApplicationRating.php
@@ -41,6 +41,9 @@ class ApplicationRating extends Enumeration
      */
     protected static function loadValues()
     {
+        static::$enumConstants[get_called_class()] = [
+            '__default' => 0,
+        ];
         $ratingOptions = TyposcriptService::getInstance()->getSettings()['ratingOptions'];
 
         foreach ($ratingOptions as $value => $option) {

--- a/Classes/Application/ApplicationRating.php
+++ b/Classes/Application/ApplicationRating.php
@@ -42,6 +42,7 @@ class ApplicationRating extends Enumeration
     protected static function loadValues()
     {
         static::$enumConstants[get_called_class()] = [
+            // Ensure this value is available as fallback in every context
             '__default' => 0,
         ];
         $ratingOptions = TyposcriptService::getInstance()->getSettings()['ratingOptions'];


### PR DESCRIPTION
This results in errors while property mapping, as the value '0' (default) should always be available