### PR TITLE
[BUGFIX] Allow for multiple CC/BCC addresses in mail messages

### DIFF
--- a/Classes/Message/AbstractMessage.php
+++ b/Classes/Message/AbstractMessage.php
@@ -4,6 +4,7 @@ namespace PAGEmachine\Ats\Message;
 use PAGEmachine\Ats\Domain\Model\Application;
 use PAGEmachine\Ats\Service\MailService;
 use PAGEmachine\Ats\Service\PdfService;
+use TYPO3\CMS\Core\Utility\MailUtility;
 
 /*
  * This file is part of the PAGEmachine ATS project.
@@ -460,8 +461,8 @@ abstract class AbstractMessage
                 $this->application,
                 $this->getRenderedSubject(),
                 $this->getRenderedBody(),
-                $this->cc,
-                $this->bcc,
+                MailUtility::parseAddresses($this->cc),
+                MailUtility::parseAddresses($this->bcc),
                 $this->useBackendUserCredentials
             );
         } elseif ($this->sendType == AbstractMessage::SENDTYPE_PDF) {

--- a/Classes/Service/MailService.php
+++ b/Classes/Service/MailService.php
@@ -54,12 +54,12 @@ class MailService implements SingletonInterface
      * @param  Application $application The application to pull information from
      * @param  string $subject
      * @param  string $body
-     * @param  string $cc
-     * @param  string $bcc
+     * @param  array $cc
+     * @param  array $bcc
      * @param  bool $useBackendUserCredentials Whether the mail should use the current backend user for sender details
      * @return void
      */
-    public function sendReplyMail(Application $application, $subject = "", $body = "", $cc = "", $bcc = "", $useBackendUserCredentials = true)
+    public function sendReplyMail(Application $application, $subject = "", $body = "", $cc = [], $bcc = [], $useBackendUserCredentials = true)
     {
         $mail = $this->callStatic(GeneralUtility::class, 'makeInstance', MailMessage::class);
 
@@ -79,11 +79,11 @@ class MailService implements SingletonInterface
             ->setTo([$application->getEmail() => $application->getFirstname() . ' ' . $application->getSurname()])
             ->setBody($renderedBody, 'text/html');
 
-        if ($cc != "") {
+        if (!empty($cc)) {
             $mail->setCc($cc);
         }
 
-        if ($bcc != "") {
+        if (!empty($bcc)) {
             $mail->setBcc($bcc);
         }
 

--- a/Classes/Service/MailService.php
+++ b/Classes/Service/MailService.php
@@ -54,8 +54,8 @@ class MailService implements SingletonInterface
      * @param  Application $application The application to pull information from
      * @param  string $subject
      * @param  string $body
-     * @param  array $cc
-     * @param  array $bcc
+     * @param  array|string $cc
+     * @param  array|string $bcc
      * @param  bool $useBackendUserCredentials Whether the mail should use the current backend user for sender details
      * @return void
      */

--- a/Tests/Unit/Message/AbstractMessageTest.php
+++ b/Tests/Unit/Message/AbstractMessageTest.php
@@ -86,7 +86,7 @@ class AbstractMessageTest extends UnitTestCase
         $this->fluidRenderingService->render("subject with replacedmarker", Argument::type("array"))->shouldBeCalled()->willReturn("rendered subject");
         $this->fluidRenderingService->render("someText", Argument::type("array"))->shouldBeCalled()->willReturn("<p>SomeText</p>");
 
-        $mailService->sendReplyMail($this->application, "rendered subject", "<p>SomeText</p>", "cc@foobar.de", "bcc@foobar.de", true)->shouldBeCalled();
+        $mailService->sendReplyMail($this->application, "rendered subject", "<p>SomeText</p>", ["cc@foobar.de"], ["bcc@foobar.de"], true)->shouldBeCalled();
 
         $this->abstractMessage->send();
     }

--- a/Tests/Unit/Message/InviteMessageTest.php
+++ b/Tests/Unit/Message/InviteMessageTest.php
@@ -103,7 +103,7 @@ class InviteMessageTest extends UnitTestCase
         $this->fluidRenderingService->render("subject", Argument::type("array"))->willReturn("subject");
         $this->fluidRenderingService->render("someText", Argument::type("array"))->willReturn("<p>SomeText</p>");
 
-        $mailService->sendReplyMail($this->application, "subject", "<p>SomeText</p>", "cc@foobar.de", "bcc@foobar.de", true)->shouldBeCalled();
+        $mailService->sendReplyMail($this->application, "subject", "<p>SomeText</p>", ["cc@foobar.de"], ["bcc@foobar.de"], true)->shouldBeCalled();
         $this->inviteMessage->send();
     }
 


### PR DESCRIPTION
This is accomplished quite easily by using TYPO3 core MailUtility functionality which parses comma-separated strings accordingly (also, its output is always an array, yay! No mixed types...).