### PR TITLE
[FEATURE] Use deactivated flag to show/hide job in applications module

### DIFF
--- a/Classes/Controller/Backend/ApplicationController.php
+++ b/Classes/Controller/Backend/ApplicationController.php
@@ -164,7 +164,7 @@ class ApplicationController extends AbstractBackendController
             'exceededApplications' => $this->applicationRepository->findDeadlineExceeded($this->settings['deadlineTime'], null, $filter),
             'newApplications' => $this->applicationRepository->findNew($this->settings['deadlineTime'], null, $filter),
             'progressApplications' => $this->applicationRepository->findInProgress($this->settings['deadlineTime'], null, $filter),
-            'jobs' => $this->jobRepository->findAll(),
+            'jobs' => $this->jobRepository->findActive(),
             'filter' => $filter,
         ]);
     }
@@ -224,7 +224,7 @@ class ApplicationController extends AbstractBackendController
     {
         $this->view->assignMultiple([
             'application' => $application,
-            'jobs' => $this->jobRepository->findAll(),
+            'jobs' => $this->jobRepository->findActive(),
         ]);
     }
 
@@ -712,7 +712,7 @@ class ApplicationController extends AbstractBackendController
     {
 
         $this->view->assign('application', $application);
-        $this->view->assign('jobs', $this->jobRepository->findAll());
+        $this->view->assign('jobs', $this->jobRepository->findActive());
         $this->view->assign('beUser', $GLOBALS['BE_USER']->user);
     }
 
@@ -802,7 +802,7 @@ class ApplicationController extends AbstractBackendController
 
     public function newAction(Application $application = null)
     {
-        $this->view->assign('jobs', $this->jobRepository->findAll());
+        $this->view->assign('jobs', $this->jobRepository->findActive());
         $this->view->assign('application', $application);
     }
 

--- a/Classes/Controller/Backend/ArchivedApplicationController.php
+++ b/Classes/Controller/Backend/ArchivedApplicationController.php
@@ -59,7 +59,7 @@ class ArchivedApplicationController extends ApplicationController
 
         $this->view->assignMultiple([
             'applications' => $this->applicationRepository->findArchived($filter),
-            'jobs' => $this->jobRepository->findActive(),
+            'jobs' => $this->jobRepository->findAll(),
             'filter' => $filter,
         ]);
     }
@@ -80,7 +80,7 @@ class ArchivedApplicationController extends ApplicationController
 
         $this->view->assignMultiple([
             'applications' => $this->applicationRepository->findPooled($filter),
-            'jobs' => $this->jobRepository->findActive(),
+            'jobs' => $this->jobRepository->findAll(),
             'filter' => $filter,
         ]);
     }
@@ -137,7 +137,7 @@ class ArchivedApplicationController extends ApplicationController
     {
         $this->view->assign('applications', $applications);
         $this->view->assign('statusOptions', WorkflowManager::getInstance()->getPlaces());
-        $this->view->assign('jobs', $this->jobRepository->findActive());
+        $this->view->assign('jobs', $this->jobRepository->findAll());
         $this->view->assign('beUser', $GLOBALS['BE_USER']->user);
     }
 

--- a/Classes/Controller/Backend/ArchivedApplicationController.php
+++ b/Classes/Controller/Backend/ArchivedApplicationController.php
@@ -59,7 +59,7 @@ class ArchivedApplicationController extends ApplicationController
 
         $this->view->assignMultiple([
             'applications' => $this->applicationRepository->findArchived($filter),
-            'jobs' => $this->jobRepository->findAll(),
+            'jobs' => $this->jobRepository->findActive(),
             'filter' => $filter,
         ]);
     }
@@ -80,7 +80,7 @@ class ArchivedApplicationController extends ApplicationController
 
         $this->view->assignMultiple([
             'applications' => $this->applicationRepository->findPooled($filter),
-            'jobs' => $this->jobRepository->findAll(),
+            'jobs' => $this->jobRepository->findActive(),
             'filter' => $filter,
         ]);
     }
@@ -137,7 +137,7 @@ class ArchivedApplicationController extends ApplicationController
     {
         $this->view->assign('applications', $applications);
         $this->view->assign('statusOptions', WorkflowManager::getInstance()->getPlaces());
-        $this->view->assign('jobs', $this->jobRepository->findAll());
+        $this->view->assign('jobs', $this->jobRepository->findActive());
         $this->view->assign('beUser', $GLOBALS['BE_USER']->user);
     }
 

--- a/Classes/Controller/Backend/NotificationApplicationController.php
+++ b/Classes/Controller/Backend/NotificationApplicationController.php
@@ -50,7 +50,7 @@ class NotificationApplicationController extends ApplicationController
 
         $this->view->assignMultiple([
             'applications' => $this->applicationRepository->findNotification($filter),
-            'jobs' => $this->jobRepository->findAll(),
+            'jobs' => $this->jobRepository->findActive(),
             'filter' => $filter,
             'messageTypes' => $this->messageFactory->getMessageTypes(),
         ]);

--- a/Classes/Domain/Repository/JobRepository.php
+++ b/Classes/Domain/Repository/JobRepository.php
@@ -32,7 +32,7 @@ class JobRepository extends Repository
         return $query->matching(
             $query->logicalAnd(
                 $query->equals('hidden', 0),
-                $query->equals('deactivated', 0)
+                $query->equals('deactivated', false)
             )
         )->execute();
     }
@@ -49,7 +49,6 @@ class JobRepository extends Repository
         $constraints = [];
 
         $constraints[] = $query->contains("userPa", $backendUser->user['uid']);
-        $constraints[] = $query->equals('deactivated', 0);
 
         foreach ($backendUser->userGroups as $group) {
             $constraints[] = $query->contains("department", $group['uid']);
@@ -58,7 +57,10 @@ class JobRepository extends Repository
         }
 
         $query->matching(
-            $query->logicalOr($constraints)
+            $query->logicalAnd(
+                $query->logicalOr($constraints),
+                $query->equals('deactivated', false)
+            )
         );
 
         return $query->execute();

--- a/Classes/Domain/Repository/JobRepository.php
+++ b/Classes/Domain/Repository/JobRepository.php
@@ -26,17 +26,14 @@ class JobRepository extends Repository
         );
     }
 
-    /**
-     * Override findAll() function to apply hidden field restriction in backend context, since all enableFields are not applied there
-     *
-     * @return QueryResult
-     */
-    public function findAll()
+    public function findActive()
     {
         $query = $this->createQuery();
-
         return $query->matching(
-            $query->equals('hidden', 0)
+            $query->logicalAnd(
+                $query->equals('hidden', 0),
+                $query->equals('deactivated', 0)
+            )
         )->execute();
     }
 
@@ -52,6 +49,7 @@ class JobRepository extends Repository
         $constraints = [];
 
         $constraints[] = $query->contains("userPa", $backendUser->user['uid']);
+        $constraints[] = $query->equals('deactivated', 0);
 
         foreach ($backendUser->userGroups as $group) {
             $constraints[] = $query->contains("department", $group['uid']);

--- a/Classes/Service/ExportService.php
+++ b/Classes/Service/ExportService.php
@@ -45,7 +45,7 @@ class ExportService implements SingletonInterface
     public function getJobOptions()
     {
         $options[''] = '';
-        $jobs = $this->jobRepository->findAll();
+        $jobs = $this->jobRepository->findActive();
         foreach ($jobs as $job) {
             $options[$job->getUid()] = $job->getJobNumber().' - '.$job->getTitle();
         }

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -30,7 +30,7 @@
 
 			<trans-unit id="tx_ats_domain_model_job.deactivated">
 				<source>Deactivated</source>
-				<target>Online-Bewerbung deaktivieren</target>
+				<target>Job in der Bewerbungsverwaltung ausblenden</target>
 			</trans-unit>
 
 			<trans-unit id="tx_ats_domain_model_job.user_pa">

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -36,7 +36,7 @@
 			</trans-unit>
 
 			<trans-unit id="tx_ats_domain_model_job.deactivated">
-				<source>Deactivated</source>
+				<source>Hide in applications module</source>
 			</trans-unit>
 
 			<trans-unit id="tx_ats_domain_model_job.career">

--- a/Tests/Unit/Controller/Backend/ApplicationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ApplicationControllerTest.php
@@ -141,7 +141,7 @@ class ApplicationControllerTest extends UnitTestCase
     {
         $filter = new ApplicationFilter();
 
-        $this->jobRepository->findAll()->shouldBeCalled();
+        $this->jobRepository->findActive()->shouldBeCalled();
 
         $this->applicationRepository->findDeadlineExceeded(Argument::any(), null, $filter)->shouldBeCalled()->willReturn(['foo']);
         $this->applicationRepository->findNew(Argument::any(), null, $filter)->shouldBeCalled()->willReturn(['bar']);


### PR DESCRIPTION
This allows for cleaner lists in BE - once a job application process is finished, the job is no longer available in filters and job selects.

New visibility mask for application modules:

- Applications (main), Mass Notification: Lists only **non-hidden** and **active** jobs
- Archive/Pools, Statistics: Lists  all jobs except deleted ones