### PR TITLE
Make user fields optional in job

### DIFF
--- a/Configuration/TCA/tx_ats_domain_model_job.php
+++ b/Configuration/TCA/tx_ats_domain_model_job.php
@@ -175,7 +175,6 @@ return [
                 'type' => 'text',
                 'cols' => '30',
                 'rows' => '5',
-                'eval' => 'required',
             ]
         ],
         'career' => [
@@ -233,7 +232,6 @@ return [
                 'items' => [],
                 'itemsProcFunc' => \PAGEmachine\Ats\TCA\FormHelper::class . '->findUserPa',
                 'size' => 5,
-                'minitems' => 1,
                 'maxitems' => 10,
                 'suppress_icons' => '1'
             ]
@@ -248,7 +246,6 @@ return [
                 'renderType' => 'selectMultipleSideBySide',
                 'itemsProcFunc' => \PAGEmachine\Ats\TCA\FormHelper::class . '->findDepartment',
                 'size' => 5,
-                'minitems' => 1,
                 'maxitems' => 10,
                 'suppress_icons' => '1'
             ]
@@ -264,7 +261,6 @@ return [
                 'items' => [],
                 'itemsProcFunc' => \PAGEmachine\Ats\TCA\FormHelper::class . '->findOfficials',
                 'size' => 5,
-                'minitems' => 1,
                 'maxitems' => 10,
                 'suppress_icons' => '1'
             ]
@@ -281,7 +277,6 @@ return [
                 // TBA
                 //'itemsProcFunc' => 'tx_jobmodul_TCAform->userCmContributors',
                 'size' => 5,
-                'minitems' => 1,
                 'maxitems' => 10,
                 'suppress_icons' => '1'
             ]


### PR DESCRIPTION
This affects the user/usergroup fields which handle assignment in backend modules.
Since jobs can also have auto-assigned department groups (which are created on the fly), the requirement here does not always make sense.

Also, it should be possible to create jobs without any workflow implication - the simplest case.