### PR TITLE
Re-enable pagination limit for list module performance

### DIFF
--- a/Configuration/TypoScript/Backend/setup.ts
+++ b/Configuration/TypoScript/Backend/setup.ts
@@ -4,6 +4,10 @@ module.tx_ats {
         dateFormat = d.m.Y
         timeFormat = H:i
 
+        list {
+          itemsPerPage = 20
+        }
+
         ratingOptions {
           0 {
             name = NONE

--- a/Configuration/TypoScript/Backend/setup_legacy.ts
+++ b/Configuration/TypoScript/Backend/setup_legacy.ts
@@ -114,6 +114,11 @@ plugin.tx_ats_jobs < plugin.tx_ats
 
 module.tx_ats {
     settings < plugin.tx_ats.settings
+    settings {
+      list {
+        itemsPerPage = 20
+      }
+    }
     persistence < plugin.tx_ats.persistence
     view < plugin.tx_ats.view
     features {

--- a/Resources/Private/Partials/Backend/Application/Table.html
+++ b/Resources/Private/Partials/Backend/Application/Table.html
@@ -1,4 +1,4 @@
 {namespace ats=PAGEmachine\Ats\ViewHelpers}
-<f:be.widget.paginate objects="{applications}" as="paginatedApplications" configuration="{itemsPerPage : 300, recordsLabel : 'Bewerbungen'}">
+<f:be.widget.paginate objects="{applications}" as="paginatedApplications" configuration="{itemsPerPage : settings.list.itemsPerPage, recordsLabel : 'Bewerbungen'}">
 	<f:render partial="Backend/Application/TableInner" arguments="{applications : paginatedApplications}" />
 </f:be.widget.paginate>

--- a/Resources/Public/Css/backend.css
+++ b/Resources/Public/Css/backend.css
@@ -23,10 +23,6 @@
 	margin: 0px;
 }
 
-.tx-ats-backend .applications-list th {
-	cursor: pointer;
-}
-
 
 /* Application list ordering icons*/
 .tx-ats-backend .applications-list th:after {

--- a/Resources/Public/JavaScript/ApplicationsModule.js
+++ b/Resources/Public/JavaScript/ApplicationsModule.js
@@ -17,8 +17,8 @@ require(
      ApplicationsModule.initializeDataTables = function() {
          $('.applications-list').DataTable({
             'searching' : false,
-            'paging' : false
-
+            'paging' : false,
+            'ordering': false
         });
      };
 


### PR DESCRIPTION
Consequence: Disable JS ordering as it is client-side only and does not take pagination into account.