### PR TITLE
[TASK] remove duplicate partial file fields.html

### DIFF
--- a/Resources/Private/Partials/Backend/Application/History/Message/fields.html
+++ b/Resources/Private/Partials/Backend/Application/History/Message/fields.html
@@ -1,6 +1,0 @@
-<ul>
-	<li><b><f:translate key="tx_ats.message.subject">Subject</f:translate></b>: {history.details.subject}</li>
-	<li><b><f:translate key="tx_ats.message.cc">Cc</f:translate></b>: {history.details.cc}</li>
-	<li><b><f:translate key="tx_ats.message.bcc">Bcc</f:translate></b>: {history.details.bcc}</li>
-	<li><b><f:translate key="tx_ats.message.body">Message</f:translate></b>: {history.details.message -> f:format.raw()}</li>
-</ul>


### PR DESCRIPTION
fields.html is a duplicate of Fields.html. This might lead to a conflict when using it in a case insensitive file system. UpperCamelCase is the recommendet naming for partial files, so fields.html is not needed at all.