### PR TITLE
Disable Crowdin integration

### DIFF
--- a/.crowdin.yml
+++ b/.crowdin.yml
@@ -1,5 +1,0 @@
-files:
-  - source: /Resources/Private/Language/
-    ignore:
-      - /Resources/Private/Language/de.*
-    translation: /%original_path%/%two_letters_code%.%original_file_name%


### PR DESCRIPTION
Right now there is next to no development here so keeping this integration around is not useful. It can be added again if development continues.